### PR TITLE
Update role content

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,3 +221,53 @@ This example from the Justice domain shows multiple `RoleOf` properties replaced
 ## Key content changes
 
 The following is a summary of the key changes made in this release.  More details are available from the [6.0 issues list](https://github.com/niemopen/niem-model/labels/6.0) in the NIEM Model issue tracker, and the change log spreadsheet in the release package.
+
+### Refactored other role components ([niemopen/niem-model#38](https://github.com/niemopen/niem-model/issues/38))
+
+In addition to removing the `RoleOf` construct from the model due to NDR updates, other properties and types using the `Role` representation term were reviewed and updated as appropriate to improve consistency with the rest of the model.
+
+**Renamed remaining RoleOf properties and types**
+
+Renamed additional properties and types that were using `RoleOf` as the class term but were not using the `RoleOf` construct as defined by the NDR:
+
+Component | Original name | Updated name
+--------- | ------------- | ------------
+Property | it:RoleOfCategory | it:PartyIDCategory
+Property | it:RoleOfCategoryDescriptionText | it:PartyRoleCategoryDescriptionText
+Property | it:RoleOfOrganizationCategoryDescriptionText | it:OrganizationRoleCategoryDescriptionText
+Property | it:RoleOfOrganizationCategory | it:OrganizationRoleCategory
+Property | it:RoleOfOrganizationCategoryAugmentationPoint | it:OrganizationRoleCategoryAugmentationPoint
+Type | it:RoleOfOrganizationCategoryType | it:OrganizationRoleCategoryType
+
+**Removed the Role representation term**
+
+Removed extraneous `Role` representation terms from a list of properties and their corresponding types and augmentation point properties.  For example, `im:AlienRole` has been renamed `im:Alien`.
+
+The following properties have been renamed:
+
+- im:AlienExchangeVisitorRole
+- im:AlienRole
+- im:AlienStudentRole
+- im:CitizenRole
+- im:ForeignBornChildOfCitizenRole
+- im:ImmigrantRole
+- im:LawfulPermanentResidentRole
+- im:NationalRole
+- im:NaturalizedCitizenRole
+- im:NonImmigrantRole
+- im:PersonCountryRole
+- im:OtherAlienRole
+- im:ResidentRole
+
+**Refactored im:PersonCountryRoleType**
+
+Refactored `im:PersonCountryRoleType` to make immigration status more widely available for reuse:
+
+- Moved `im:ImmigrationStatus` from `im:PersonCountryRoleType` to `im:PersonAugmentationType`, making it available wherever `nc:PersonType` is used.
+- Updated `im:PersonCountryRoleType` to extend `nc:PersonType`.
+
+**Refactored scr:PersonRole**
+
+- Added a new Screening augmentation for `nc:PersonType`.
+- Moved `scr:PersonRole` from `scr:ScreeningPersonType` to the new augmentation.
+- Removed properties `scr:AgentPersonRole`, `scr:AgentAssociation`, and type `scr:AgentAssociationType` as they are no longer needed to relate an agent to a role.

--- a/README.md
+++ b/README.md
@@ -5,15 +5,13 @@ This is the NIEM 6.0 major release.
 
 In a major version, content may be updated in any namespace, including Core. Changes may also be made to the NIEM architecture, which may be reflected in the structure and layout of the NIEM schemas.
 
-## Key changes
+## Key updates based on NDR 6.0 changes
 
-The following is a summary of the key changes made in this release.  More details are available from the [6.0 issues list](https://github.com/niemopen/niem-model/labels/6.0) in the NIEM Model issue tracker, and the change log spreadsheet in the release package.
+The following are the key changes made to the model based on updates to the NDR for version 6.0.
 
-### Naming and Design Rules (NDR) 6.0 updates
+*Note: The example XML schema snippets below have been simplified and shortened for better readability.*
 
-The following are the key changes made to the model based on updates to the NDR.
-
-#### Updated namespace URIs ([niemopen/niem-model#25](https://github.com/niemopen/niem-model/issues/25))
+### Updated namespace URIs ([niemopen/niem-model#25](https://github.com/niemopen/niem-model/issues/25))
 
 NIEM is now an OASIS Open Project.  URIs for each namespace have been updated to follow the [OASIS Naming Directives, XML Namespace Identifiers and Namespace Documents](http://docs.oasis-open.org/specGuidelines/ndr/namingDirectives.html#xml-namespaces).
 
@@ -24,3 +22,202 @@ NIEM is now an OASIS Open Project.  URIs for each namespace have been updated to
 <!-- URI for NIEM Core for 6.0 -->
 <xs:schema targetNamespace="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/" ...>
 ```
+
+### Removed the roles construct ([niemopen/niem-naming-design-rules#6](https://github.com/niemopen/niem-naming-design-rules/issues/6))
+
+NIEM has previously used `RoleOf` properties and role types to be able to relate multiple objects in a message back to the same entity.  NDR 6.0 drops the role construct in favor of using the `structures:uri` attribute instead: objects in a message with the same uri value should be interpreted as different roles of the same entity.  This change was made to make NIEM simpler to learn and use, and to improve consistency for implementers.
+
+#### Updates to simple role types
+
+Simple role types that contained a single `RoleOf` property have been updated to use type extension.
+
+In the following example from the Learning and Development domain, `lrn-dev:StudentType` has been updated to remove the `nc:RoleOfPerson` property and to extend `nc:PersonType`:
+
+```diff
+  <xs:complexType name="StudentType">
+    <xs:complexContent>
+-     <xs:extension base="structures:ObjectType">
++     <xs:extension base="nc:PersonType">
+        <xs:sequence>
+-         <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="lrn-dev:StudentID" minOccurs="0" maxOccurs="unbounded"/>
+          <!-- ... -->
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+```
+
+<details markdown="1">
+  <summary>Expand to view the list of former simple role types and their new parent types in 6.0</summary>
+  <br />
+
+| Type | New parent type |
+|:---- |:--------------- |
+| cyber:UserType | nc:PersonType |
+| em:FirstResponderType | nc:PersonType |
+| em:PatientType | nc:PersonType |
+| em:ResponderType | nc:PersonType |
+| em:ServiceCallOriginatorType | nc:PersonType |
+| hs:CaseParticipantType | nc:PersonType |
+| hs:CaseworkerType | nc:PersonType |
+| hs:ChildType | nc:PersonType |
+| hs:ChildVictimType | nc:PersonType |
+| hs:CourtEventAttendeeType | nc:PersonType |
+| hs:JuvenileType | nc:PersonType |
+| hs:MissingChildRelatedPersonType | nc:PersonType |
+| hs:PatientType | nc:PersonType |
+| hs:PetitionerType | nc:PersonType |
+| hs:PharmacistType | nc:PersonType |
+| hs:RequiredPartyType | nc:PersonType |
+| hs:SeriousHabitualOffenderType | nc:PersonType |
+| hs:StudentType | nc:PersonType |
+| im:ICEEmployeeType | nc:PersonType |
+| im:ICEOfficerType | nc:PersonType |
+| it:AgentType | it:PartyType |
+| it:BrokerType | it:PartyType |
+| it:BuyerType | it:PartyType |
+| it:CarrierType | it:PartyType |
+| it:ConsigneeType | it:PartyType |
+| it:ConsignorType | it:PartyType |
+| it:ConsolidatorType | it:PartyType |
+| it:ConsortiumCarrierType | it:PartyType |
+| it:ContainerTerminalOperatorType | it:PartyType |
+| it:DeconsolidatorType | it:PartyType |
+| it:ExporterType | it:PartyType |
+| it:ImporterType | it:PartyType |
+| it:IntermediateCarrierType | it:PartyType |
+| it:IntermediateConsigneeType | it:PartyType |
+| it:ManufacturerType | it:PartyType |
+| it:MasterType | it:PartyType |
+| it:NonVesselOperatingCarrierType | it:PartyType |
+| it:NotifyPartyType | it:PartyType |
+| it:ProcessingEstablishmentType | it:PartyType |
+| it:SellerType | it:PartyType |
+| it:StevedoreType | it:PartyType |
+| it:StuffingEstablishmentType | it:PartyType |
+| it:UNDGContactType | it:PartyType |
+| j:CrashDriverType | nc:PersonType |
+| j:CrashNonMotoristType | nc:PersonType |
+| j:CrashPassengerType | nc:PersonType |
+| j:CrashPersonType | nc:PersonType |
+| j:CrashVehicleOccupantType | nc:PersonType |
+| j:CrashVehicleType | nc:VehicleType |
+| j:CriminalOrganizationType | nc:OrganizationType |
+| j:DeporteeType | nc:PersonType |
+| j:EnforcementOfficialType | nc:PersonType |
+| j:HearingInvestigatorType | nc:PersonType |
+| j:JudicialOfficialType | nc:PersonType |
+| j:JurorType | nc:PersonType |
+| j:MissingPersonType | nc:PersonType |
+| j:OtherInvolvedPersonType | nc:PersonType |
+| j:PanelMemberType | nc:PersonType |
+| j:ParticipantType | nc:PersonType |
+| j:RegisteredOffenderType | nc:PersonType |
+| j:StaffMemberType | nc:PersonType |
+| j:ToolType | nc:ItemType |
+| j:VehicleBranderType | nc:OrganizationType |
+| j:WitnessType | nc:PersonType |
+| lrn-dev:StudentType | nc:PersonType |
+| nc:EquipmentType | nc:ItemType |
+| nc:PublicationType | nc:DocumentType |
+| nc:ReportType | nc:DocumentType |
+| nc:WeaponType | nc:ItemType |
+| scr:ScreenedAlienType | im:AlienRoleType |
+| scr:ScreeningPersonType | nc:PersonType |
+
+</details>
+
+#### Updates to multi-option role types for persons, organizations, and items
+
+Role types that contained `nc:RoleOfPerson` and `nc:RoleOfOrganization` properties, and optionally `nc:RoleOfItem`, have been updated to extend `nc:EntityType`.
+
+This example from the Justice domain shows multiple `RoleOf` properties replaced by extension from `nc:EntityType`.
+
+```diff
+  <xs:complexType name="SubjectType">
+    <xs:complexContent>
+-     <xs:extension base="structures:ObjectType">
++     <xs:extension base="nc:EntityType">
+        <xs:sequence>
+-         <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
+-         <xs:element ref="nc:RoleOfOrganization" minOccurs="0" maxOccurs="unbounded"/>
+          <!-- ... -->
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+```
+
+<details markdown="1">
+  <summary>Expand to view the list of former role types that now extend `nc:EntityType`</summary>
+
+  <br />
+
+- j:LesseeType
+- j:LessorType
+- j:LienHolderType
+- j:PawnBrokerType
+- j:SubjectType
+- j:VictimType
+
+</details>
+
+#### Updates to other multi-option role types
+
+Other non-entity multi-option role types have been updated to use the NDR Representation pattern.  Since a type in XML cannot extend multiple parent types, a substitution group is used instead:
+
+- An abstract property ending with the representation term `Representation` is added to the type.
+- The former `RoleOf` properties are converted to substitutions for the new abstract `Representation` property.
+
+*Note that this solution is similar to the one above that leverages `nc:EntityType`, which uses the representation pattern to represent an object that could be a person, organization, or item.  In this case, the combination of `RoleOf` properties are unique, so new representation properties have to be created.*
+
+This example from the Justice domain shows multiple `RoleOf` properties replaced by the representation pattern.
+
+```diff
+  <xs:complexType name="EvidenceType">
+    <xs:complexContent>
+      <xs:extension base="structures:ObjectType">
+        <xs:sequence>
+-         <xs:element ref="nc:RoleOfItem" minOccurs="0" maxOccurs="unbounded"/>
+-         <xs:element ref="j:RoleOfBinary" minOccurs="0" maxOccurs="unbounded"/>
+-         <xs:element ref="j:RoleOfBiometric" minOccurs="0" maxOccurs="unbounded"/>
++         <xs:element ref="j:EvidenceRepresentation" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="j:EvidenceAmount" minOccurs="0" maxOccurs="unbounded"/>
+          <!-- ... -->
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
++ <xs:element name="EvidenceBinary" type="nc:BinaryType" substitutionGroup="j:EvidenceRepresentation" />
++ <xs:element name="EvidenceBiometric" type="biom:BiometricDataType" substitutionGroup="j:EvidenceRepresentation" />
++ <xs:element name="EvidenceItem" type="nc:ItemType" substitutionGroup="j:EvidenceRepresentation" />
++ <xs:element name="EvidenceRepresentation" abstract="true" />
+
+- <xs:element name="RoleOfBinary" type="nc:BinaryType" />
+- <xs:element name="RoleOfBiometric" type="biom:BiometricDataType" />
+  <!-- RoleOfItem is not defined in the Justice domain but is also being removed from Core -->
+```
+
+<details markdown="1">
+  <summary>Expand to view the list of former role types that now employ the representation pattern</summary>
+
+  <br />
+
+- j:EvidenceType
+  - *Previously contained:*
+  - nc:RoleOfItem
+  - j:RoleOfBinary
+  - j:RoleOfBiometric
+- mo:TargetType
+  - *Previously contained:*
+  - nc:RoleOfPerson
+  - mo:RoleOfUnit
+  - mo:RoleOfFacility
+
+</details>
+
+## Key content changes
+
+The following is a summary of the key changes made in this release.  More details are available from the [6.0 issues list](https://github.com/niemopen/niem-model/labels/6.0) in the NIEM Model issue tracker, and the change log spreadsheet in the release package.

--- a/xsd/domains/cyber.xsd
+++ b/xsd/domains/cyber.xsd
@@ -7426,9 +7426,8 @@
       <xs:documentation>A data type for a person operating in the role of a user</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="cyber:IncidentUserCategoryCode" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="cyber:UserAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>

--- a/xsd/domains/emergencyManagement.xsd
+++ b/xsd/domains/emergencyManagement.xsd
@@ -4131,9 +4131,8 @@
       <xs:documentation>A data type for a person who is a first responder</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="em:PersonHumanResource" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="em:JobTitleOrRole" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="em:CheckInOutRecord" minOccurs="0" maxOccurs="unbounded"/>
@@ -5911,9 +5910,8 @@
       <xs:documentation>A data type for a person receiving or registered to receive medical treatment.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="em:PatientConditionName" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="em:PatientConditionOnsetDate" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="em:PatientDiagnosis" minOccurs="0" maxOccurs="unbounded"/>
@@ -6754,9 +6752,8 @@
       <xs:documentation>A data type for an expert or staff that participates in emergency preparedness and response activities.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="em:ResponderIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="em:ResponderOrganization" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="em:ResponderAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
@@ -6950,13 +6947,12 @@
       <xs:documentation>A data type for a structure that contains additional information about a Service Call Originator</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
           <xs:element ref="em:CallerCategoryText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:EnforcementOfficialBadgeIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:EnforcementUnitIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:OrganizationName" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="em:ServiceCallOriginatorAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>

--- a/xsd/domains/hs.xsd
+++ b/xsd/domains/hs.xsd
@@ -670,9 +670,8 @@
       <xs:documentation>A data type for information about a participant.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:CaseParticipantInvolvementText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:CaseParticipantAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
@@ -783,9 +782,8 @@
       <xs:documentation>A data type for information about the caseworker.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:CaseworkerCategoryAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:CaseworkerAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
@@ -1302,9 +1300,8 @@
       <xs:documentation>A data type for information about a person who has not yet reached the age of legal majority (i.e., adulthood).</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:ChildRemovalDate" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:CountyOfCustodyText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:ChildAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
@@ -1332,12 +1329,11 @@
       <xs:documentation>A data type for information about a person who has not yet reached the age of majority and in whose interest a child welfare case has been initiated.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
           <xs:element ref="hs:ChildRemovalDate" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:RemovalIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:FatherUnknownText" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:PlacementChangeReasonAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:PlacementText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:ChildVictimAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
@@ -1507,9 +1503,8 @@
       <xs:documentation>A data type for details about court event attendees</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:CaseInvolvementDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:CourtEventInputIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:CourtEventAttendeeAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
@@ -3019,9 +3014,8 @@
       <xs:documentation>A data type for a juvenile.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:JuvenileArrestedFriendsIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:JuvenileAttentionDisorderDiagnosisIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:JuvenileChildEverAdoptedIndicator" minOccurs="0" maxOccurs="unbounded"/>
@@ -3541,11 +3535,10 @@
       <xs:documentation>A data type for a person related to a missing child.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
           <xs:element ref="hs:ChildRelationshipText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:Warrant" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:MissingChildRelatedPersonAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -3887,7 +3880,7 @@
       <xs:documentation>A data type for a person receiving medical care.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
           <xs:element ref="hs:CustodialEntity" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:MedicalSummary" minOccurs="0" maxOccurs="unbounded"/>
@@ -3896,7 +3889,6 @@
           <xs:element ref="hs:ProviderEntity" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:ReportingEntity" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:SpeciesAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:PatientAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -4402,9 +4394,8 @@
       <xs:documentation>A data type for information about the person filing the petition.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:PetitionerAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -4415,11 +4406,10 @@
       <xs:documentation>A data type for a person who is professionally qualified to prepare and dispense medicinal drugs.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
           <xs:element ref="hs:NPIIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:StateLicenseIdentification" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:PharmacistAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -5459,9 +5449,8 @@
       <xs:documentation>A data type for the party required to the next court event.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:RequiredPartyAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -5644,9 +5633,8 @@
       <xs:documentation>A data type for information about a person who is considered a Serious Habitual Offender Drug Involved individual by a law enforcement agency.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:SeriousHabitualOffenderDeterminingJurisdiction" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:SeriousHabitualOffenderScoreText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:SeriousHabitualOffenderParentNotifiedIndicator" minOccurs="0" maxOccurs="unbounded"/>
@@ -6213,9 +6201,8 @@
       <xs:documentation>A data type for a student.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:StudentCurrentEducationGradeLevelAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:StudentCurrentEducationDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:StudentCurrentEducationEnrollmentIndicator" minOccurs="0" maxOccurs="unbounded"/>

--- a/xsd/domains/immigration.xsd
+++ b/xsd/domains/immigration.xsd
@@ -2449,9 +2449,8 @@
       <xs:documentation>A data type for the classification of the person employed by the Department of Homeland Security (DHS) Immigration and Customs Enforcement (ICE) agency.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="im:ICEEmployeeAssistantUSAttorneyIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="im:ICEEmployeeAttorneyIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="im:ICEEmployeeBadgeIdentification" minOccurs="0" maxOccurs="unbounded"/>
@@ -2470,9 +2469,8 @@
       <xs:documentation>A data type for the classification of the authorized enforcement officer employed by the Department of Homeland Security (DHS) Immigration and Customs Enforcement (ICE) agency.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="im:ICEOfficerCategoryText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="im:ICEOfficerAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
@@ -10360,11 +10358,6 @@
   <xs:element name="ResponseYesIndicator" type="niem-xs:boolean" nillable="true">
     <xs:annotation>
       <xs:documentation>True if Yes has been specified; false otherwise.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="RoleOfAlienAbstract" abstract="true">
-    <xs:annotation>
-      <xs:documentation>A data concept for the role of an Alien who is being processed as part of a Screening Encounter.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="ScholarshipGrantAmount" type="nc:AmountType" nillable="true">

--- a/xsd/domains/immigration.xsd
+++ b/xsd/domains/immigration.xsd
@@ -60,7 +60,7 @@
           <xs:element ref="scr:AlertCategoryClassificationCode" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="im:AlertDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:AlertMedicalIndicator" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:AlienRole" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:Alien" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="im:AlienAlertAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -128,17 +128,17 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="AlienExchangeVisitorRoleType">
+  <xs:complexType name="AlienExchangeVisitorType">
     <xs:annotation>
       <xs:documentation>A data type for a non-immigrant alien who visits the United States to participate in either an educational or cultural exchange program that is approved by the United States Department of State.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="im:NonImmigrantRoleType">
+      <xs:extension base="im:NonImmigrantType">
         <xs:sequence>
           <xs:element ref="im:ExchangeVisitorAdmission" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:ExchangeVisitorCategoryCode" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:ExchangeVisitorCategoryDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:AlienExchangeVisitorRoleAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:AlienExchangeVisitorAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -185,33 +185,6 @@
         <xs:sequence>
           <xs:element ref="im:AlienMiscellaneousIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="im:AlienMiscellaneousNumberIDAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-  <xs:complexType name="AlienRoleType">
-    <xs:annotation>
-      <xs:documentation>A data type for a foreign born person who is not a citizen of the United States.</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="im:PersonCountryRoleType">
-        <xs:sequence>
-          <xs:element ref="im:AlienAlert" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:AlienCautionMedicalConditionCode" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:AlienEncounter" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:AlienFelonCategoryText" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:AlienFelonDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:AlienFile" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:AlienIDDetails" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:AlienLocation" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:AlienMatchCandidate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:AlienPriorDeportationIndicator" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:AlienSpecialClassCategoryText" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:AlienSpecialClassCodeDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:AlienVoluntaryReturnIndicator" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="scr:AlienDetention" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="scr:EnforcementEncounter" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:AlienRoleAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -336,15 +309,42 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="AlienStudentRoleType">
+  <xs:complexType name="AlienStudentType">
     <xs:annotation>
       <xs:documentation>A data type for a non-immigrant alien enrolled full-time in an approved, accredited or certified United States educational or vocational program</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="im:NonImmigrantRoleType">
+      <xs:extension base="im:NonImmigrantType">
         <xs:sequence>
           <xs:element ref="im:AlienStudentAdmission" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:AlienStudentRoleAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:AlienStudentAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="AlienType">
+    <xs:annotation>
+      <xs:documentation>A data type for a foreign born person who is not a citizen of the United States.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="im:PersonCountryRoleType">
+        <xs:sequence>
+          <xs:element ref="im:AlienAlert" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:AlienCautionMedicalConditionCode" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:AlienEncounter" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:AlienFelonCategoryText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:AlienFelonDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:AlienFile" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:AlienIDDetails" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:AlienLocation" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:AlienMatchCandidate" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:AlienPriorDeportationIndicator" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:AlienSpecialClassCategoryText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:AlienSpecialClassCodeDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:AlienVoluntaryReturnIndicator" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="scr:AlienDetention" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="scr:EnforcementEncounter" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:AlienAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -1908,14 +1908,14 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="CitizenRoleType">
+  <xs:complexType name="CitizenType">
     <xs:annotation>
       <xs:documentation>A data type for the role of Citizen that is played by a Person with respect to a Country</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
       <xs:extension base="im:PersonCountryRoleType">
         <xs:sequence>
-          <xs:element ref="im:CitizenRoleAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:CitizenAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -2431,15 +2431,15 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="ForeignBornChildOfCitizenRoleType">
+  <xs:complexType name="ForeignBornChildOfCitizenType">
     <xs:annotation>
       <xs:documentation>A data type for the role of Foreign Born Child of Citizen that is played by a Person with respect to a Country.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="im:CitizenRoleType">
+      <xs:extension base="im:CitizenType">
         <xs:sequence>
           <xs:element ref="im:CitizenshipCertificateIdentification" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:ForeignBornChildOfCitizenRoleAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:ForeignBornChildOfCitizenAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -2477,14 +2477,14 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="ImmigrantRoleType">
+  <xs:complexType name="ImmigrantType">
     <xs:annotation>
       <xs:documentation>A data type for the role of Immigrant that is played by a Person with respect to a Country</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="im:AlienRoleType">
+      <xs:extension base="im:AlienType">
         <xs:sequence>
-          <xs:element ref="im:ImmigrantRoleAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:ImmigrantAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -2640,7 +2640,7 @@
           <xs:element ref="im:BeneficiaryReceivedOtherBenefitsCaseReceiptNumberIdentification" minOccurs="0" maxOccurs="1"/>
           <xs:element ref="im:PermanentResidentAdjustmentApplicant" minOccurs="0" maxOccurs="1"/>
           <xs:element ref="im:PermanentResidentAdjustmentCaseReceiptNumberIdentification" minOccurs="0" maxOccurs="1"/>
-          <xs:element ref="im:AlienExchangeVisitorRole" minOccurs="0" maxOccurs="1"/>
+          <xs:element ref="im:AlienExchangeVisitor" minOccurs="0" maxOccurs="1"/>
           <xs:element ref="im:ExchangeVisitorTwoYearForeignResidentRequirementIndicator" minOccurs="0" maxOccurs="1"/>
           <xs:element ref="im:ExchangeVisitorTwoYearForeignResidentWaiverIndicator" minOccurs="0" maxOccurs="1"/>
           <xs:element ref="im:ExchangeVisitorCaseReceiptNumberIdentification" minOccurs="0" maxOccurs="1"/>
@@ -7847,15 +7847,15 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="LawfulPermanentResidentRoleType">
+  <xs:complexType name="LawfulPermanentResidentType">
     <xs:annotation>
       <xs:documentation>A data type for the role of Lawful Permanent Resident that is played by a Person with respect to a Country</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="im:ImmigrantRoleType">
+      <xs:extension base="im:ImmigrantType">
         <xs:sequence>
           <xs:element ref="im:LawfulPermanentResidentReasonDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:LawfulPermanentResidentRoleAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:LawfulPermanentResidentAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -7885,7 +7885,7 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="NationalRoleType">
+  <xs:complexType name="NationalType">
     <xs:annotation>
       <xs:documentation>A data type for the role of National that is played by a Person with respect to a Country</xs:documentation>
     </xs:annotation>
@@ -7893,35 +7893,35 @@
       <xs:extension base="im:PersonCountryRoleType">
         <xs:sequence>
           <xs:element ref="im:NationalReasonDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:NationalRoleAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:NationalAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="NaturalizedCitizenRoleType">
+  <xs:complexType name="NaturalizedCitizenType">
     <xs:annotation>
       <xs:documentation>A data type for the role of Naturalized Citizen that is played by a Person with respect to a Country</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="im:CitizenRoleType">
+      <xs:extension base="im:CitizenType">
         <xs:sequence>
           <xs:element ref="im:NaturalizationAddress" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="im:NaturalizationCertificateIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="im:NaturalizationDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:NaturalizationCourtName" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:NaturalizedCitizenRoleAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:NaturalizedCitizenAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="NonImmigrantRoleType">
+  <xs:complexType name="NonImmigrantType">
     <xs:annotation>
       <xs:documentation>A data type for the role of NonImmigrant that is played by a Person with respect to a Country</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="im:AlienRoleType">
+      <xs:extension base="im:AlienType">
         <xs:sequence>
-          <xs:element ref="im:NonImmigrantRoleAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:NonImmigrantAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -7944,14 +7944,14 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="OtherAlienRoleType">
+  <xs:complexType name="OtherAlienType">
     <xs:annotation>
       <xs:documentation>A data type for the Other Alien role that is played by a Person who cannot be categorized as either an Immigrant or NonImmigrant with respect to a Country</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="im:AlienRoleType">
+      <xs:extension base="im:AlienType">
         <xs:sequence>
-          <xs:element ref="im:OtherAlienRoleAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:OtherAlienAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -7980,6 +7980,7 @@
     <xs:complexContent>
       <xs:extension base="structures:AugmentationType">
         <xs:sequence>
+          <xs:element ref="im:ImmigrationStatus" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PersonUnionAssociation" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -8004,10 +8005,8 @@
       <xs:documentation>A data type for the role played by the Person with respect to a Country</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="im:ImmigrationStatus" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:Person" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="im:PersonCountryRoleAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -8062,7 +8061,7 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="ResidentRoleType">
+  <xs:complexType name="ResidentType">
     <xs:annotation>
       <xs:documentation>A data type for the role of Resident that is played by a Person with respect to a Country</xs:documentation>
     </xs:annotation>
@@ -8070,7 +8069,7 @@
       <xs:extension base="im:PersonCountryRoleType">
         <xs:sequence>
           <xs:element ref="im:ResidentReasonDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="im:ResidentRoleAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:ResidentAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -8440,6 +8439,11 @@
       <xs:documentation>True if there is an alert warning associated with an alien; false otherwise.</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="Alien" type="im:AlienType" substitutionGroup="im:PersonCountryRole" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A foreign born person who is not a citizen of the United States.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="AlienAlert" type="im:AlienAlertType" nillable="true">
     <xs:annotation>
       <xs:documentation>An alert for the Department of Homeland Security (DHS), Immigration and Customs Enforcement (ICE) if the alien has been formally removed from the U.S. or could pose a risk based on safety or other factors.</xs:documentation>
@@ -8453,6 +8457,11 @@
   <xs:element name="AlienAsylumRequestIndicator" type="niem-xs:boolean" nillable="true">
     <xs:annotation>
       <xs:documentation>True if the encounter is with an alien seeking asylum; false otherwise</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="AlienAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for AlienType.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="AlienBorderCrossingIndicator" type="niem-xs:boolean" nillable="true">
@@ -8490,24 +8499,24 @@
       <xs:documentation>An augmentation point for AlienEncounterType.</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="AlienExchangeVisitor" type="im:AlienExchangeVisitorType" substitutionGroup="im:NonImmigrant" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A non-immigrant alien who visits the United States to participate in either an educational or cultural exchange program that is approved by the United States Department of State.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="AlienExchangeVisitorAdmissionAugmentationPoint" abstract="true">
     <xs:annotation>
       <xs:documentation>An augmentation point for AlienExchangeVisitorAdmissionType.</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="AlienExchangeVisitorAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for AlienExchangeVisitorType.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="AlienExchangeVisitorProgram" type="nc:ProgramType" nillable="true">
     <xs:annotation>
       <xs:documentation>An educational or cultural program of study sponsored by an authorized institution in the United States and offered to non-immigrant aliens.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="AlienExchangeVisitorRole" type="im:AlienExchangeVisitorRoleType" substitutionGroup="im:NonImmigrantRole" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A non-immigrant alien who visits the United States to participate in either an educational or cultural exchange program that is approved by the United States Department of State.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="AlienExchangeVisitorRoleAugmentationPoint" abstract="true">
-    <xs:annotation>
-      <xs:documentation>An augmentation point for AlienExchangeVisitorRoleType.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="AlienFelonCategoryText" type="nc:TextType" nillable="true">
@@ -8610,16 +8619,6 @@
       <xs:documentation>True if the encounter is with a non-criminal alien who has a tendency to slip back into previously recorded criminal activities; false otherwise.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="AlienRole" type="im:AlienRoleType" substitutionGroup="im:PersonCountryRole" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A foreign born person who is not a citizen of the United States.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="AlienRoleAugmentationPoint" abstract="true">
-    <xs:annotation>
-      <xs:documentation>An augmentation point for AlienRoleType.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
   <xs:element name="AlienSmuggledCostAmount" type="nc:AmountType" nillable="true">
     <xs:annotation>
       <xs:documentation>A cost associated with smuggling an alien to the United States.</xs:documentation>
@@ -8640,6 +8639,11 @@
       <xs:documentation>A field indicating the description for the associated special class code for alien person detention.</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="AlienStudent" type="im:AlienStudentType" substitutionGroup="im:NonImmigrant" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A non-immigrant alien enrolled full-time in an approved, accredited or certified United States educational or vocational program</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="AlienStudentAdmission" type="im:AlienStudentAdmissionType" nillable="true">
     <xs:annotation>
       <xs:documentation>An entrance of a non-immigrant alien into full-time in an approved, accredited or certified United States educational or vocational program.</xs:documentation>
@@ -8648,6 +8652,11 @@
   <xs:element name="AlienStudentAdmissionAugmentationPoint" abstract="true">
     <xs:annotation>
       <xs:documentation>An augmentation point for AlienStudentAdmissionType.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="AlienStudentAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for AlienStudentType.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="AlienStudentAuthorization" type="im:AlienStudentAuthorizationType" nillable="true">
@@ -8703,16 +8712,6 @@
   <xs:element name="AlienStudentProgramExtensionRequestAugmentationPoint" abstract="true">
     <xs:annotation>
       <xs:documentation>An augmentation point for AlienStudentProgramExtensionRequestType.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="AlienStudentRole" type="im:AlienStudentRoleType" substitutionGroup="im:NonImmigrantRole" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A non-immigrant alien enrolled full-time in an approved, accredited or certified United States educational or vocational program</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="AlienStudentRoleAugmentationPoint" abstract="true">
-    <xs:annotation>
-      <xs:documentation>An augmentation point for AlienStudentRoleType.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="AlienVoluntaryReturnIndicator" type="niem-xs:boolean" nillable="true">
@@ -8930,14 +8929,14 @@
       <xs:documentation>True if the requester would like a change of non immigrant status; false otherwise.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="CitizenRole" type="im:CitizenRoleType" substitutionGroup="im:PersonCountryRole" nillable="true">
+  <xs:element name="Citizen" type="im:CitizenType" substitutionGroup="im:PersonCountryRole" nillable="true">
     <xs:annotation>
       <xs:documentation>a native or naturalized person who owes allegiance to a government and is entitled to protection from it</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="CitizenRoleAugmentationPoint" abstract="true">
+  <xs:element name="CitizenAugmentationPoint" abstract="true">
     <xs:annotation>
-      <xs:documentation>An augmentation point for CitizenRoleType.</xs:documentation>
+      <xs:documentation>An augmentation point for CitizenType.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="CitizenshipCertificateIdentification" type="nc:IdentificationType" nillable="true">
@@ -9440,14 +9439,14 @@
       <xs:documentation>A method used to select and arrange financial support for EXCHANGE VISITORs.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="ForeignBornChildOfCitizenRole" type="im:ForeignBornChildOfCitizenRoleType" substitutionGroup="im:CitizenRole" nillable="true">
+  <xs:element name="ForeignBornChildOfCitizen" type="im:ForeignBornChildOfCitizenType" substitutionGroup="im:Citizen" nillable="true">
     <xs:annotation>
-      <xs:documentation>A role of Foreign Born Child of Citizen Role Type that is played by a Person with respect to a Country</xs:documentation>
+      <xs:documentation>A foreign-born child of a citizen with respect to a country.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="ForeignBornChildOfCitizenRoleAugmentationPoint" abstract="true">
+  <xs:element name="ForeignBornChildOfCitizenAugmentationPoint" abstract="true">
     <xs:annotation>
-      <xs:documentation>An augmentation point for ForeignBornChildOfCitizenRoleType.</xs:documentation>
+      <xs:documentation>An augmentation point for ForeignBornChildOfCitizenType.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="FormAllotmentQuantity" type="nc:QuantityType" nillable="true">
@@ -9545,14 +9544,14 @@
       <xs:documentation>A kind of Department of Homeland Security (DHS), Immigration and Customs Enforcement (ICE) officer.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="ImmigrantRole" type="im:ImmigrantRoleType" substitutionGroup="im:AlienRole" nillable="true">
+  <xs:element name="Immigrant" type="im:ImmigrantType" substitutionGroup="im:Alien" nillable="true">
     <xs:annotation>
       <xs:documentation>A person immigrating to a country with a path to staying legally in a country.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="ImmigrantRoleAugmentationPoint" abstract="true">
+  <xs:element name="ImmigrantAugmentationPoint" abstract="true">
     <xs:annotation>
-      <xs:documentation>An augmentation point for ImmigrantRoleType.</xs:documentation>
+      <xs:documentation>An augmentation point for ImmigrantType.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="ImmigrantVisaApplicant" type="nc:PersonType" nillable="true">
@@ -9810,19 +9809,19 @@
       <xs:documentation>A free form field with detailed description about the attorney.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="LawfulPermanentResidentReasonDescriptionText" type="nc:TextType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A description of the reason why a Person is considered a lawful permanent resident.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="LawfulPermanentResidentRole" type="im:LawfulPermanentResidentRoleType" substitutionGroup="im:ImmigrantRole" nillable="true">
+  <xs:element name="LawfulPermanentResident" type="im:LawfulPermanentResidentType" substitutionGroup="im:Immigrant" nillable="true">
     <xs:annotation>
       <xs:documentation>A person that has been made a lawful resident of a country.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="LawfulPermanentResidentRoleAugmentationPoint" abstract="true">
+  <xs:element name="LawfulPermanentResidentAugmentationPoint" abstract="true">
     <xs:annotation>
-      <xs:documentation>An augmentation point for LawfulPermanentResidentRoleType.</xs:documentation>
+      <xs:documentation>An augmentation point for LawfulPermanentResidentType.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LawfulPermanentResidentReasonDescriptionText" type="nc:TextType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A description of the reason why a Person is considered a lawful permanent resident.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="LeftCountryIndicator" type="niem-xs:boolean" nillable="true">
@@ -9900,19 +9899,19 @@
       <xs:documentation>True if there are multiple beneficiaries of the benefit request; false otherwise</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="NationalReasonDescriptionText" type="nc:TextType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A description of the reason why a Person is considered a National.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="NationalRole" type="im:NationalRoleType" substitutionGroup="im:PersonCountryRole" nillable="true">
+  <xs:element name="National" type="im:NationalType" substitutionGroup="im:PersonCountryRole" nillable="true">
     <xs:annotation>
       <xs:documentation>An individual who owes his sole allegiance to the United States, including all U.S. citizens, and including some individuals who are not U.S. citizens. These individuals would include citizens of certain U.S. possessions such as American Samoa and Northern Mariana Islands</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="NationalRoleAugmentationPoint" abstract="true">
+  <xs:element name="NationalAugmentationPoint" abstract="true">
     <xs:annotation>
-      <xs:documentation>An augmentation point for NationalRoleType.</xs:documentation>
+      <xs:documentation>An augmentation point for NationalType.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="NationalReasonDescriptionText" type="nc:TextType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A description of the reason why a Person is considered a National.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="NaturalizationAddress" type="nc:AddressType" substitutionGroup="nc:Address" nillable="true">
@@ -9930,14 +9929,14 @@
       <xs:documentation>A description of the details of the alien's U.S. Naturalization.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="NaturalizedCitizenRole" type="im:NaturalizedCitizenRoleType" substitutionGroup="im:CitizenRole" nillable="true">
+  <xs:element name="NaturalizedCitizen" type="im:NaturalizedCitizenType" substitutionGroup="im:Citizen" nillable="true">
     <xs:annotation>
       <xs:documentation>A Person who has been naturalized in a country as a new citizen.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="NaturalizedCitizenRoleAugmentationPoint" abstract="true">
+  <xs:element name="NaturalizedCitizenAugmentationPoint" abstract="true">
     <xs:annotation>
-      <xs:documentation>An augmentation point for NaturalizedCitizenRoleType.</xs:documentation>
+      <xs:documentation>An augmentation point for NaturalizedCitizenType.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="NextSessionStartDate" type="nc:DateType" nillable="true">
@@ -9945,19 +9944,19 @@
       <xs:documentation>A date on which the next school session begins for the alien student.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="NonImmigrantInspectionAdmissionStatus" type="nc:StatusType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A current status of non-immigrant inspection and admission into the country.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="NonImmigrantRole" type="im:NonImmigrantRoleType" substitutionGroup="im:AlienRole" nillable="true">
+  <xs:element name="NonImmigrant" type="im:NonImmigrantType" substitutionGroup="im:Alien" nillable="true">
     <xs:annotation>
       <xs:documentation>A person immigrating a country with no immigration path to staying legally in a country.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="NonImmigrantRoleAugmentationPoint" abstract="true">
+  <xs:element name="NonImmigrantAugmentationPoint" abstract="true">
     <xs:annotation>
-      <xs:documentation>An augmentation point for NonImmigrantRoleType.</xs:documentation>
+      <xs:documentation>An augmentation point for NonImmigrantType.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="NonImmigrantInspectionAdmissionStatus" type="nc:StatusType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A current status of non-immigrant inspection and admission into the country.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="NonImmigrantWorkerPetitionConcurrentlyFiledIndicator" type="niem-xs:boolean" nillable="true">
@@ -10020,14 +10019,14 @@
       <xs:documentation>True if the sole or surviving parent has irrevocable released the orphan for emigration and adoption in writing; false otherwise</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="OtherAlienRole" type="im:OtherAlienRoleType" substitutionGroup="im:AlienRole" nillable="true">
+  <xs:element name="OtherAlien" type="im:OtherAlienType" substitutionGroup="im:Alien" nillable="true">
     <xs:annotation>
-      <xs:documentation>A data type for the Other Alien role that is played by a Person who cannot be categorized as either an Immigrant or NonImmigrant with respect to a Country</xs:documentation>
+      <xs:documentation>A person who cannot be categorized as either an Immigrant or NonImmigrant with respect to a Country.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="OtherAlienRoleAugmentationPoint" abstract="true">
+  <xs:element name="OtherAlienAugmentationPoint" abstract="true">
     <xs:annotation>
-      <xs:documentation>An augmentation point for OtherAlienRoleType.</xs:documentation>
+      <xs:documentation>An augmentation point for OtherAlienType.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="OtherFundsAmount" type="nc:AmountType" nillable="true">
@@ -10325,19 +10324,19 @@
       <xs:documentation>A date on which the alien needs to be removed from the United States based on the removal order.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="ResidentReasonDescriptionText" type="nc:TextType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A description of the reason why a Person is considered a Resident.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="ResidentRole" type="im:ResidentRoleType" substitutionGroup="im:PersonCountryRole" nillable="true">
+  <xs:element name="Resident" type="im:ResidentType" substitutionGroup="im:PersonCountryRole" nillable="true">
     <xs:annotation>
       <xs:documentation>A person who resides in a particular place permanently or for an extended period</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="ResidentRoleAugmentationPoint" abstract="true">
+  <xs:element name="ResidentAugmentationPoint" abstract="true">
     <xs:annotation>
-      <xs:documentation>An augmentation point for ResidentRoleType.</xs:documentation>
+      <xs:documentation>An augmentation point for ResidentType.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="ResidentReasonDescriptionText" type="nc:TextType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A description of the reason why a Person is considered a Resident.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="ResponseDescriptionText" type="nc:TextType" nillable="true">

--- a/xsd/domains/internationalTrade.xsd
+++ b/xsd/domains/internationalTrade.xsd
@@ -91,14 +91,13 @@
       <xs:documentation>A data type for a party authorized to act on behalf of another person, organization or thing.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:AgentIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:AgentQualityAssuranceIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:AgentStatusCodeText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:AgentStatusText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:AgentAuthorizationIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:AgentAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -158,11 +157,10 @@
       <xs:documentation>A data type for a name [and address] of a party to which merchandise or services are sold.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:BrokerIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:BrokerIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:BrokerAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -173,11 +171,10 @@
       <xs:documentation>A data type for a name [and address] of a party to which merchandise or services are sold.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:BuyerIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:BuyerIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:BuyerAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -188,13 +185,12 @@
       <xs:documentation>A data type for a name [and address] of party providing the transport of goods between named points.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:CarrierCodeAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:CarrierIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:CarrierIDCategory" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:CarrierName" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:CarrierAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -240,11 +236,10 @@
       <xs:documentation>A data type representing the Name [and address] of party to which goods are consigned.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:ConsigneeIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ConsigneeIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ConsigneeAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -340,11 +335,10 @@
       <xs:documentation>A data type representing the Name [and address] of the party consigning goods as stipulated in the transport contract by the party ordering transport.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:ConsignorIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ConsignorIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ConsignorAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -355,11 +349,10 @@
       <xs:documentation>A data type representing the Name [and address] of the freight forwarder combining individual smaller consignments into a single larger shipment so called consolidated shipment) that is sent to a counterpart who mirrors the consolidator's activity by dividing the consolidated consignment into its original components.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:ConsolidatorIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ConsolidatorIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ConsolidatorAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -370,11 +363,10 @@
       <xs:documentation>A data type representing the Name [and address] of the consortium carrier.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:ConsortiumCarrierIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ConsortiumCarrierIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ConsortiumCarrierAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -385,11 +377,10 @@
       <xs:documentation>A data type representing the Container Terminal Operator</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:ContainerTerminalOperatorIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ContainerTerminalOperatorIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ContainerTerminalOperatorAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -543,11 +534,10 @@
       <xs:documentation>A data type representing the Name [and address] of the receiving party of a consolidated shipment, who divides the latter into its original single consignments and undertakes to make them available to be delivered.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:DeconsolidatorIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:DeconsolidatorIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:DeconsolidatorAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -623,11 +613,10 @@
       <xs:documentation>A data type for a name [and address] of party who makes - or on whose behalf - the export declaration - is made - and who is the owner of the goods or has similar right of disposal over them at the time when the declaration is accepted.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:ExporterIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ExporterIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ExporterAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -769,11 +758,10 @@
       <xs:documentation>A data type providing the name [and address] of party who makes-or on whose behalf a Customs clearing agent or other authorized person makes- an import declaration. This may include a person who has possession of the goods or to whom the goods are consigned.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:ImporterIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ImporterIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ImporterAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -784,11 +772,10 @@
       <xs:documentation>A data type representing a transit (in-bond) movement, the identity of the carrier's which transport the goods from consignor to exporting carrier and from importing carrier to consignee. A party providing the transport of goods between named points.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:IntermediateCarrierIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:IntermediateCarrierIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:IntermediateCarrierAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -799,11 +786,10 @@
       <xs:documentation>A data type representing the transit (in-bond) movement, the identity of the intermediate consignee who may take possession of the goods from consignor to exporting carrier and from importing carrier to consignee.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:IntermediateConsigneeIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:IntermediateConsigneeIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:IntermediateConsigneeAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -914,11 +900,10 @@
       <xs:documentation>A data type representing the Name [and address] of party which manufactures goods.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:ManufacturerIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ManufacturerIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ManufacturerAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -929,11 +914,10 @@
       <xs:documentation>A data type representing the Name of the Master of a means of transport such as a vessel.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="nc:OrganizationType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:MasterIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:MasterIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:MasterNationalityText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:MasterAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
@@ -957,11 +941,10 @@
       <xs:documentation>A data type representing a common carrier that does not operate the vessels.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:NonVesselOperatingCarrierIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:NonVesselOperatingCarrierIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:NonVesselOperatingCarrierAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -972,11 +955,10 @@
       <xs:documentation>A data type for a name [and address] of party to be notified.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:NotifyPartyIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:NotifyPartyIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:NotifyPartyAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -1118,11 +1100,10 @@
       <xs:documentation>A data type for a name [and address] of slaughtering, freezing, or other processing establishment.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="nc:OrganizationType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:ProcessingEstablishmentIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ProcessingEstablishmentIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ProcessingEstablishmentAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -1178,11 +1159,10 @@
       <xs:documentation>A data type for a Name [and address] of a party selling merchandise or services to a buyer</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:SellerIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:SellerIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:SellerAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -1254,8 +1234,6 @@
           <xs:element ref="it:ShippingContainerLegalStatusIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ShippingContainerISO6346Abstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ShippingContainerKindAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="cbrn:ConveyanceColorPrimaryCode" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="cbrn:ConveyanceColorSecondaryCode" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="cbrn:RemarkText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:ShippingContainerAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
@@ -1267,11 +1245,10 @@
       <xs:documentation>A data type representing a party loading or unloading the cargo of (a ship) or vessel</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:StevedoreIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:StevedoreIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:StevedoreAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -1282,11 +1259,10 @@
       <xs:documentation>A data type representing the Name [and address] of the location where the goods are loaded into the transport equipment.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:StuffingEstablishmentIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:StuffingEstablishmentIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:StuffingEstablishmentAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -1483,11 +1459,10 @@
       <xs:documentation>A data type representing the Name [and address] of dangerous goods contact person or party who can provide detailed information concerning the dangerous goods shipment</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="it:PartyType">
         <xs:sequence>
           <xs:element ref="it:UNDGContactIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:UNDGContactIDCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfParty" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:UNDGContactAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -3486,11 +3461,6 @@
   <xs:element name="RoleOfOrganizationCategoryDescriptionText" type="nc:TextType" nillable="true">
     <xs:annotation>
       <xs:documentation>A text description of the role played by the party/organization in a given transaction.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="RoleOfParty" type="it:PartyType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A role of the Organization, Person or Thing associated with processing a Cargo entry.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="RoleOfPartyCategory" type="it:PartyIDCategoryType" nillable="true">

--- a/xsd/domains/internationalTrade.xsd
+++ b/xsd/domains/internationalTrade.xsd
@@ -992,6 +992,20 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  <xs:complexType name="OrganizationRoleCategoryType">
+    <xs:annotation>
+      <xs:documentation>A data type for the role played by the Party/Organization in the given context of a transaction</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="structures:ObjectType">
+        <xs:sequence>
+          <xs:element ref="it:OrganizationRoleCategoryDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="it:OrganizationRoleCategory" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="it:OrganizationRoleCategoryAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
   <xs:complexType name="PackageType">
     <xs:annotation>
       <xs:documentation>A data type for an item packaged for containment, preservation, promotion, and/or protection of an article.</xs:documentation>
@@ -1030,9 +1044,9 @@
     <xs:complexContent>
       <xs:extension base="structures:ObjectType">
         <xs:sequence>
-          <xs:element ref="it:RoleOfPartyCategoryDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="it:PartyRoleCategoryDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:PartyID" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfPartyCategory" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="it:PartyIDCategory" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:PartyIDCategoryAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -1118,20 +1132,6 @@
         <xs:sequence>
           <xs:element ref="it:RepresentativePersonFunctionText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:RepresentativePersonAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-  <xs:complexType name="RoleOfOrganizationCategoryType">
-    <xs:annotation>
-      <xs:documentation>A data type for the role played by the Party/Organization in the given context of a transaction</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
-        <xs:sequence>
-          <xs:element ref="it:RoleOfOrganizationCategoryDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfOrganizationCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="it:RoleOfOrganizationCategoryAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -3218,6 +3218,21 @@
       <xs:documentation>A name of the organization that operates a site.</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="OrganizationRoleCategory" type="it:OrganizationRoleCategoryType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A Category of the role played by an organization in the given context of the transaction(Ex. Clearing house, Brokerage house...)</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="OrganizationRoleCategoryAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for RoleOfOrganizationCategoryType.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="OrganizationRoleCategoryDescriptionText" type="nc:TextType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A text description of the role played by the party/organization in a given transaction.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="OtherChargesDeductionsAmount" type="nc:AmountType" nillable="true">
     <xs:annotation>
       <xs:documentation>An amount added or subtracted from the total invoice price not previously taken into account when determining the Customs value.</xs:documentation>
@@ -3308,6 +3323,11 @@
       <xs:documentation>An augmentation point for PartyIDType.</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="PartyIDCategory" type="it:PartyIDCategoryType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A data type identifying the role of the Organization, Person or Thing associated with processing a Cargo entry.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="PartyIDCategoryAugmentationPoint" abstract="true">
     <xs:annotation>
       <xs:documentation>An augmentation point for PartyIDCategoryType.</xs:documentation>
@@ -3331,6 +3351,11 @@
   <xs:element name="PartyRelationshipIndicator" type="niem-xs:boolean" nillable="true">
     <xs:annotation>
       <xs:documentation>True if there is any relationship between two parties; false otherwise/if no relationship exists.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="PartyRoleCategoryDescriptionText" type="nc:TextType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A description of the role of the Party in a given context/transaction</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="PaymentMethodCategoryText" type="nc:TextType" nillable="true">
@@ -3438,34 +3463,14 @@
       <xs:documentation>True if a hazardous material is a residue; false otherwise.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="RoleOfOrganizationCategory" type="it:RoleOfOrganizationCategoryType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A Category of the role played by an organization in the given context of the transaction(Ex. Clearing house, Brokerage house...)</xs:documentation>
-    </xs:annotation>
-  </xs:element>
   <xs:element name="RoleOfOrganizationCategoryAbstract" abstract="true">
     <xs:annotation>
       <xs:documentation>A data concept for a role played by the Party/Organization in the given context of a transaction</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="RoleOfOrganizationCategoryAugmentationPoint" abstract="true">
-    <xs:annotation>
-      <xs:documentation>An augmentation point for RoleOfOrganizationCategoryType.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
   <xs:element name="RoleOfOrganizationCategoryCode" type="itcodes:RoleOfPartyCategoryCodeType" substitutionGroup="it:RoleOfOrganizationCategoryAbstract" nillable="true">
     <xs:annotation>
       <xs:documentation>A role played by the Party/Organization in the given context of a transaction</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="RoleOfOrganizationCategoryDescriptionText" type="nc:TextType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A text description of the role played by the party/organization in a given transaction.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="RoleOfPartyCategory" type="it:PartyIDCategoryType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A data type identifying the role of the Organization, Person or Thing associated with processing a Cargo entry.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="RoleOfPartyCategoryAbstract" abstract="true">
@@ -3476,11 +3481,6 @@
   <xs:element name="RoleOfPartyCategoryCode" type="itcodes:RoleOfPartyCategoryCodeType" substitutionGroup="it:RoleOfPartyCategoryAbstract" nillable="true">
     <xs:annotation>
       <xs:documentation>A role played by the Party/Organization in the given context of a transaction</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="RoleOfPartyCategoryDescriptionText" type="nc:TextType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A description of the role of the Party in a given context/transaction</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Seal" type="it:SealType" nillable="true">

--- a/xsd/domains/jxdm.xsd
+++ b/xsd/domains/jxdm.xsd
@@ -2092,9 +2092,8 @@
       <xs:documentation>A data type for a motor vehicle driver involved in a traffic accident.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:DriverLicense" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:CrashDriverContributingCircumstancesAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:CrashDriverDistractionAbstract" minOccurs="0" maxOccurs="unbounded"/>
@@ -2124,9 +2123,8 @@
       <xs:documentation>A data type for a non-motorist involved in a Traffic Accident.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:NonMotoristStrikingVehicle" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:NonMotoristActionBeforeCrashAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:NonMotoristCategoryAbstract" minOccurs="0" maxOccurs="unbounded"/>
@@ -2143,9 +2141,8 @@
       <xs:documentation>A data type for a motor vehicle passenger involved into a Traffic Accident.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:CrashPassengerAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -2169,9 +2166,8 @@
       <xs:documentation>A data type for any person involved in a traffic accident.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:CrashPersonEMSTransportation" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:CrashPersonInjury" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:AlcoholTestResultQuantityText" minOccurs="0" maxOccurs="unbounded"/>
@@ -2224,9 +2220,8 @@
       <xs:documentation>A data type for any vehicle occupant involved in a traffic accident.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:OccupantAirBagDeployedAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:OccupantEjectionAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:OccupantProtectionSystemUseAbstract" minOccurs="0" maxOccurs="unbounded"/>
@@ -2243,9 +2238,8 @@
       <xs:documentation>A data type for a motor vehicle involved in a traffic accident.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:VehicleType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfItem" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:VehicleTrafficControlDeviceOperationalIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:CrashVehicleOccupantsQuantity" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:CrashVehicleLegalSpeedRateMeasure" minOccurs="0" maxOccurs="unbounded"/>
@@ -2494,9 +2488,8 @@
       <xs:documentation>A data type for an organization that is formed to or intentionally conducts illegal activities.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:OrganizationType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfOrganization" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:CriminalOrganizationCautionText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:CriminalOrganizationMembershipHighQuantityText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:CriminalOrganizationMembershipInitiationText" minOccurs="0" maxOccurs="unbounded"/>
@@ -2699,9 +2692,8 @@
       <xs:documentation>A data type for a person who is expelled from country by a governmental authority.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="im:ActualDeportationDate" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:DeporteeAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
@@ -3385,9 +3377,8 @@
       <xs:documentation>A data type for a person involved in the enforcement of law.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:EnforcementOfficialActivityCategoryAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:EnforcementOfficialAssignmentCategoryAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:EnforcementOfficialBadgeIdentification" minOccurs="0" maxOccurs="unbounded"/>
@@ -3527,9 +3518,7 @@
     <xs:complexContent>
       <xs:extension base="structures:ObjectType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfItem" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:RoleOfBinary" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:RoleOfBiometric" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="j:EvidenceRepresentation" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:EvidenceAmount" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:EvidenceDocumentationBinary" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:EvidenceItemContactInformation" minOccurs="0" maxOccurs="unbounded"/>
@@ -3896,9 +3885,8 @@
       <xs:documentation>A data type for a name of a staff member assigned as an investigator to a hearing.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:HearingInvestigatorEmployeeAssignedDate" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:HearingInvestigatorEmployeeRequestDeniedReasonText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:HearingInvestigatorAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
@@ -5043,9 +5031,8 @@
       <xs:documentation>A data type for a person involved in a judicial area of government.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:JudicialOfficialBarMembership" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:JudicialOfficialCourt" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:JudicialOfficialFirm" minOccurs="0" maxOccurs="unbounded"/>
@@ -5062,9 +5049,8 @@
       <xs:documentation>A data type for a person who serves on a jury and listens to a case to determine the guilt or innocence of a person accused of a crime.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:JurorDismissedDate" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:JurorDismissedIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:JurorDismissedReasonText" minOccurs="0" maxOccurs="unbounded"/>
@@ -5175,10 +5161,8 @@
       <xs:documentation>A data type for an entity which has a contract to use a vehicle.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:EntityType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfOrganization" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:LesseeJurisdictionAuthorityAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:AddressCountyAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:LesseeAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
@@ -5191,10 +5175,8 @@
       <xs:documentation>A data type for an entity which conveys a vehicle by way of a lease.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:EntityType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfOrganization" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:LessorIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:LessorAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
@@ -5206,10 +5188,8 @@
       <xs:documentation>A data type for an entity that has a security interest on a property item.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:EntityType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfOrganization" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:Lien" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:LienHolderAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
@@ -5604,9 +5584,8 @@
       <xs:documentation>A data type for details of a person whose whereabouts are unknown.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:MissingPersonCircumstanceAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:MissingPersonDeclarationDate" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:MissingPersonDeclarationPerson" minOccurs="0" maxOccurs="unbounded"/>
@@ -6149,9 +6128,8 @@
       <xs:documentation>A data type for a person who is involved in an activity, but does not meet the criteria for other roles.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:OtherInvolvedPersonSequenceID" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:InvolvementAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:OtherInvolvedPersonAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
@@ -6180,9 +6158,8 @@
       <xs:documentation>A data type for a person who is a member of a panel.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:PanelMemberRoleText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:PanelMemberTitleText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:PanelMemberAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
@@ -6545,9 +6522,8 @@
       <xs:documentation>A data type for a person who takes part in something.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:ParticipantRoleCategoryAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:ParticipantRelationshipText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:ParticipantAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
@@ -6838,10 +6814,8 @@
       <xs:documentation>A data type for a pawn broker.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:EntityType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfOrganization" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:PawnBrokerBranchName" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:PawnBrokerLicenseIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:PawnBrokerName" minOccurs="0" maxOccurs="unbounded"/>
@@ -8752,9 +8726,8 @@
       <xs:documentation>A data type for information about a person who is required to register information with a law enforcement agency due to having been convicted of a certain type of crime.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:RegisteredOffenderAbsconderIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:RegisteredOffenderConditionsText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:RegisteredOffenderConviction" minOccurs="0" maxOccurs="unbounded"/>
@@ -9147,9 +9120,8 @@
       <xs:documentation>A data type for a person who is employed by the agency or institution.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:StaffMemberAffiliatedPrimaryProgram" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:StaffMemberAppliedForce" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:StaffMemberAssignedWeapon" minOccurs="0" maxOccurs="unbounded"/>
@@ -9588,10 +9560,8 @@
       <xs:documentation>A data type for a person or organization that is involved or suspected of being involved in a violation of a criminal statute, ordinance or rule.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:EntityType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:RoleOfOrganization" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:DNACollectionStatusAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:InvoluntaryMedicationAction" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:Remark" minOccurs="0" maxOccurs="unbounded"/>
@@ -10108,9 +10078,8 @@
       <xs:documentation>A data type for a role of an item used to facilitate commission of a crime.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:ItemType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfItem" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:ToolUsageText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:ToolUser" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:ToolAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
@@ -10229,9 +10198,8 @@
       <xs:documentation>A data type for an organization which brands vehicles.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:OrganizationType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfOrganization" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:VehicleBranderIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:VehicleBranderCategoryAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:VehicleBranderAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
@@ -10375,11 +10343,8 @@
       <xs:documentation>A data type for a person who suffers injury, loss, or death as a result of an incident.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:EntityType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:RoleOfOrganization" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:RoleOfItem" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:VictimContactedIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:VictimMO" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:VictimSeeksRestitutionDescriptionIndicator" minOccurs="0" maxOccurs="unbounded"/>
@@ -10540,9 +10505,8 @@
       <xs:documentation>A data type for a person who has observed an incident.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:WitnessIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:WitnessSequenceNumberText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:WitnessAccountDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
@@ -17161,6 +17125,16 @@
       <xs:documentation>An augmentation point for EvidenceType.</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="EvidenceBinary" type="nc:BinaryType" substitutionGroup="j:EvidenceRepresentation" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A binary object that acts as evidence.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="EvidenceBiometric" type="biom:BiometricDataType" substitutionGroup="j:EvidenceRepresentation" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A biometric data object that acts as evidence.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="EvidenceCollector" type="nc:PersonType" nillable="true">
     <xs:annotation>
       <xs:documentation>A person who collected a particular piece of evidence.</xs:documentation>
@@ -17174,6 +17148,11 @@
   <xs:element name="EvidenceDocumentationBinary" type="nc:BinaryType" nillable="true">
     <xs:annotation>
       <xs:documentation>An evidentiary document encoded in binary relating to the evidence.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="EvidenceItem" type="nc:ItemType" substitutionGroup="j:EvidenceRepresentation" nillable="true">
+    <xs:annotation>
+      <xs:documentation>An item that acts as evidence.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="EvidenceItemContactInformation" type="nc:ContactInformationType" nillable="true">
@@ -17214,6 +17193,11 @@
   <xs:element name="EvidenceReceiptIdentification" type="nc:IdentificationType" nillable="true">
     <xs:annotation>
       <xs:documentation>An identification for a receipt issued for collection, analysis, and movement of Evidence.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="EvidenceRepresentation" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A data concept for a representation of evidence.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="EvidenceReturnedIndicator" type="niem-xs:boolean" nillable="true">
@@ -25619,16 +25603,6 @@
   <xs:element name="RiskScoreValue" type="nc:NumericType" nillable="true">
     <xs:annotation>
       <xs:documentation>A numeric score for the risk based on assessment.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="RoleOfBinary" type="nc:BinaryType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A binary object of which the role object is a function.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="RoleOfBiometric" type="biom:BiometricDataType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A biometric object of which the role object is a function.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="RoommateAssociation" type="nc:PersonAssociationType" nillable="true">

--- a/xsd/domains/learn-dev.xsd
+++ b/xsd/domains/learn-dev.xsd
@@ -264,9 +264,8 @@
       <xs:documentation>A data type for a person formally engaged in learning, especially one enrolled in a school or college.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="lrn-dev:StudentID" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="lrn-dev:StudentIdentificationSystemName" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="lrn-dev:PersonGeneralIntelligenceText" minOccurs="0" maxOccurs="unbounded"/>

--- a/xsd/domains/mo.xsd
+++ b/xsd/domains/mo.xsd
@@ -8524,13 +8524,11 @@
     <xs:complexContent>
       <xs:extension base="structures:ObjectType">
         <xs:sequence>
+          <xs:element ref="mo:TargetRepresentation" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="mo:TargetIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="mo:TargetResultingDamage" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="mo:MeanPointOfImpactAimpoint" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="mo:DesiredPointOfImpactAimpoint" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="mo:RoleOfUnit" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="mo:RoleOfFacility" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="mo:TargetLocation" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="mo:MILSTD2525-B-SIDC-Code" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="mo:MILSTD2525-C-SIDC-Code" minOccurs="0" maxOccurs="unbounded"/>
@@ -12589,21 +12587,6 @@
       <xs:documentation>A date for the end of a specified retention period.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="RoleOfFacility" type="nc:FacilityType" substitutionGroup="nc:RoleOfAbstract" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A facility, of which the containing object is a role.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="RoleOfSensor" type="mo:SensorType" substitutionGroup="nc:RoleOfAbstract" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A sensor, of which the containing object is a role.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="RoleOfUnit" type="mo:UnitType" substitutionGroup="nc:RoleOfAbstract" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A unit, of which the containing object is a role.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
   <xs:element name="RollChangeValue" type="nc:Degree180PlusMinusType" nillable="true">
     <xs:annotation>
       <xs:documentation>A rate of change of angle of rotation of a thing about its longitudinal axis, measured in degrees per second.</xs:documentation>
@@ -12969,6 +12952,11 @@
       <xs:documentation>A detailed description of the target software using the Common Platform Enumeration Standard.</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="TargetFacility" type="nc:FacilityType" substitutionGroup="mo:TargetRepresentation" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A facility that represents a target.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="TargetIdentification" type="nc:IdentificationType" nillable="true">
     <xs:annotation>
       <xs:documentation>An identification of a target.</xs:documentation>
@@ -12977,6 +12965,16 @@
   <xs:element name="TargetLocation" type="nc:LocationType" nillable="true">
     <xs:annotation>
       <xs:documentation>A geographic coordinate of the target.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="TargetPerson" type="nc:PersonType" substitutionGroup="mo:TargetRepresentation" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A person that represents a target.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="TargetRepresentation" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A data concept for a representation of a target.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="TargetResultingDamage" type="mo:DamageType" nillable="true">
@@ -13027,6 +13025,11 @@
   <xs:element name="TargetTestSettingAbstract" abstract="true">
     <xs:annotation>
       <xs:documentation>A data concept for representation of specific settings for the target.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="TargetUnit" type="mo:UnitType" substitutionGroup="mo:TargetRepresentation" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A unit that represents a target.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="TaskAugmentation" type="mo:TaskAugmentationType" substitutionGroup="nc:TaskAugmentationPoint" nillable="true">

--- a/xsd/domains/screening.xsd
+++ b/xsd/domains/screening.xsd
@@ -21012,9 +21012,8 @@
       <xs:documentation>A data type for additional information about an Alien being screened.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="im:AlienRoleType">
         <xs:sequence>
-          <xs:element ref="im:RoleOfAlienAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:PrincipalIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:VisaWaiverIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:AlienCategoryText" minOccurs="0" maxOccurs="unbounded"/>
@@ -21067,9 +21066,8 @@
       <xs:documentation>A data type for additional information about Persons being Screened</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:PersonType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:PersonCategory" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:PersonRole" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:PersonTelephoneNumber" minOccurs="0" maxOccurs="unbounded"/>

--- a/xsd/domains/screening.xsd
+++ b/xsd/domains/screening.xsd
@@ -310,20 +310,6 @@
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
-  <xs:complexType name="AgentAssociationType">
-    <xs:annotation>
-      <xs:documentation>A data type for a relationship between a Person and a Person Role</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="nc:AssociationType">
-        <xs:sequence>
-          <xs:element ref="scr:AgentPerson" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="scr:AgentPersonRole" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="scr:AgentAssociationAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
   <xs:complexType name="AircraftFlightPlanSummaryAssociationType">
     <xs:annotation>
       <xs:documentation>A data type for an association between a flight plan summary, an aircraft, and a carrier.</xs:documentation>
@@ -19871,6 +19857,18 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  <xs:complexType name="PersonAugmentationType">
+    <xs:annotation>
+      <xs:documentation>A data type for additional information about a person.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="structures:AugmentationType">
+        <xs:sequence>
+          <xs:element ref="scr:PersonRole" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
   <xs:complexType name="PersonBiometricAssociationType">
     <xs:annotation>
       <xs:documentation>A data type for an association that distinguishes physical characteristics captured at the time of person encounter.</xs:documentation>
@@ -20779,7 +20777,7 @@
     <xs:complexContent>
       <xs:extension base="structures:ObjectType">
         <xs:sequence>
-          <xs:element ref="im:NaturalizedCitizenRole" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="im:NaturalizedCitizen" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="im:AlienNumberIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PersonName" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PersonBirthDate" minOccurs="0" maxOccurs="unbounded"/>
@@ -20873,7 +20871,6 @@
         <xs:sequence>
           <xs:element ref="scr:AgentPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PersonEncounter" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="scr:AgentPersonRole" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:PhysicalEncounterAgentAssociationAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -21012,7 +21009,7 @@
       <xs:documentation>A data type for additional information about an Alien being screened.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="im:AlienRoleType">
+      <xs:extension base="im:AlienType">
         <xs:sequence>
           <xs:element ref="scr:PrincipalIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:VisaWaiverIndicator" minOccurs="0" maxOccurs="unbounded"/>
@@ -21069,7 +21066,6 @@
       <xs:extension base="nc:PersonType">
         <xs:sequence>
           <xs:element ref="scr:PersonCategory" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="scr:PersonRole" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:PersonTelephoneNumber" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:PersonIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:Biographic" minOccurs="0" maxOccurs="unbounded"/>
@@ -21889,24 +21885,9 @@
       <xs:documentation>True if DHS had advanced manifest information on the traveler prior to person crossing; false otherwise.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="AgentAssociation" type="scr:AgentAssociationType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>An association between a PERSON and a PERSON ROLE</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="AgentAssociationAugmentationPoint" abstract="true">
-    <xs:annotation>
-      <xs:documentation>An augmentation point for AgentAssociationType.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
   <xs:element name="AgentPerson" type="nc:PersonType" nillable="true">
     <xs:annotation>
       <xs:documentation>An Agent of Department of Homeland Security.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="AgentPersonRole" type="scr:PersonRoleType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A part played by a Person in an Encounter.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="AircraftFlightPlanSummaryAssociation" type="scr:AircraftFlightPlanSummaryAssociationType" nillable="true">
@@ -23552,6 +23533,11 @@
   <xs:element name="PersonArrivalDate" type="nc:DateType" nillable="true">
     <xs:annotation>
       <xs:documentation>A date that a Person arrived in the U.S.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="PersonAugmentation" type="scr:PersonAugmentationType" substitutionGroup="nc:PersonAugmentationPoint" nillable="true">
+    <xs:annotation>
+      <xs:documentation>Additional information about a person.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="PersonBiometricAssociation" type="scr:PersonBiometricAssociationType" nillable="true">

--- a/xsd/niem-core.xsd
+++ b/xsd/niem-core.xsd
@@ -1821,9 +1821,8 @@
       <xs:documentation>A data type for a tangible property (other than land or buildings) of more or less durable nature which is useful in carrying on the operations of a business.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:ItemType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfItem" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:EquipmentIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:EquipmentName" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:EquipmentAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
@@ -4068,9 +4067,8 @@
       <xs:documentation>A data type for a collection of written, printed, illustrated, or blank sheets, made of paper, parchment, or other material, usually fastened together to hinge at one side.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:DocumentType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfDocument" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PublicationAuthorText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PublicationDate" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PublicationISBNID" minOccurs="0" maxOccurs="unbounded"/>
@@ -4283,9 +4281,8 @@
       <xs:documentation>A data type for an account given of a particular matter, especially in the form of an official document, after thorough investigation or consideration by an appointed person or body.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:DocumentType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfDocument" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:ReportAssignee" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:ReportCoverageDateRange" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:ReportDueDate" minOccurs="0" maxOccurs="unbounded"/>
@@ -4894,9 +4891,8 @@
       <xs:documentation>A data type for a property item used as an instrument of attack or defense.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="nc:ItemType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfItem" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:WeaponUser" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:WeaponInvolvedInActivity" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:WeaponUsageAbstract" minOccurs="0" maxOccurs="unbounded"/>
@@ -12833,31 +12829,6 @@
   <xs:element name="RiskReductionProgram" type="nc:ProgramType" nillable="true">
     <xs:annotation>
       <xs:documentation>A program designed to lower the probability of undesirable outcomes.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="RoleOfAbstract" abstract="true">
-    <xs:annotation>
-      <xs:documentation>A data concept for a property of a role object. This specifies the base object, of which the role object is a function.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="RoleOfDocument" type="nc:DocumentType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A document of whom the role object is a function.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="RoleOfItem" type="nc:ItemType" substitutionGroup="nc:RoleOfAbstract" nillable="true">
-    <xs:annotation>
-      <xs:documentation>An entity of whom the role object is a function.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="RoleOfOrganization" type="nc:OrganizationType" substitutionGroup="nc:RoleOfAbstract" nillable="true">
-    <xs:annotation>
-      <xs:documentation>An organization of whom the role object is a function.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="RoleOfPerson" type="nc:PersonType" substitutionGroup="nc:RoleOfAbstract" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A person of whom the role object is a function.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="RollValue" type="nc:Degree180PlusMinusType" nillable="true">


### PR DESCRIPTION


### Removed the roles construct ([niemopen/niem-naming-design-rules#6](https://github.com/niemopen/niem-naming-design-rules/issues/6))

NIEM has previously used `RoleOf` properties and role types to be able to relate multiple objects in a message back to the same entity.  NDR 6.0 drops the role construct in favor of using the `structures:uri` attribute instead: objects in a message with the same uri value should be interpreted as different roles of the same entity.  This change was made to make NIEM simpler to learn and use, and to improve consistency for implementers.

#### Updates to simple role types

Simple role types that contained a single `RoleOf` property have been updated to use type extension.

In the following example from the Learning and Development domain, `lrn-dev:StudentType` has been updated to remove the `nc:RoleOfPerson` property and to extend `nc:PersonType`:

```diff
  <xs:complexType name="StudentType">
    <xs:complexContent>
-     <xs:extension base="structures:ObjectType">
+     <xs:extension base="nc:PersonType">
        <xs:sequence>
-         <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
          <xs:element ref="lrn-dev:StudentID" minOccurs="0" maxOccurs="unbounded"/>
          <!-- ... -->
        </xs:sequence>
      </xs:extension>
    </xs:complexContent>
  </xs:complexType>
```

<details markdown="1">
  <summary>Expand to view the list of former simple role types and their new parent types in 6.0</summary>
  <br />

| Type | New parent type |
|:---- |:--------------- |
| cyber:UserType | nc:PersonType |
| em:FirstResponderType | nc:PersonType |
| em:PatientType | nc:PersonType |
| em:ResponderType | nc:PersonType |
| em:ServiceCallOriginatorType | nc:PersonType |
| hs:CaseParticipantType | nc:PersonType |
| hs:CaseworkerType | nc:PersonType |
| hs:ChildType | nc:PersonType |
| hs:ChildVictimType | nc:PersonType |
| hs:CourtEventAttendeeType | nc:PersonType |
| hs:JuvenileType | nc:PersonType |
| hs:MissingChildRelatedPersonType | nc:PersonType |
| hs:PatientType | nc:PersonType |
| hs:PetitionerType | nc:PersonType |
| hs:PharmacistType | nc:PersonType |
| hs:RequiredPartyType | nc:PersonType |
| hs:SeriousHabitualOffenderType | nc:PersonType |
| hs:StudentType | nc:PersonType |
| im:ICEEmployeeType | nc:PersonType |
| im:ICEOfficerType | nc:PersonType |
| it:AgentType | it:PartyType |
| it:BrokerType | it:PartyType |
| it:BuyerType | it:PartyType |
| it:CarrierType | it:PartyType |
| it:ConsigneeType | it:PartyType |
| it:ConsignorType | it:PartyType |
| it:ConsolidatorType | it:PartyType |
| it:ConsortiumCarrierType | it:PartyType |
| it:ContainerTerminalOperatorType | it:PartyType |
| it:DeconsolidatorType | it:PartyType |
| it:ExporterType | it:PartyType |
| it:ImporterType | it:PartyType |
| it:IntermediateCarrierType | it:PartyType |
| it:IntermediateConsigneeType | it:PartyType |
| it:ManufacturerType | it:PartyType |
| it:MasterType | it:PartyType |
| it:NonVesselOperatingCarrierType | it:PartyType |
| it:NotifyPartyType | it:PartyType |
| it:ProcessingEstablishmentType | it:PartyType |
| it:SellerType | it:PartyType |
| it:StevedoreType | it:PartyType |
| it:StuffingEstablishmentType | it:PartyType |
| it:UNDGContactType | it:PartyType |
| j:CrashDriverType | nc:PersonType |
| j:CrashNonMotoristType | nc:PersonType |
| j:CrashPassengerType | nc:PersonType |
| j:CrashPersonType | nc:PersonType |
| j:CrashVehicleOccupantType | nc:PersonType |
| j:CrashVehicleType | nc:VehicleType |
| j:CriminalOrganizationType | nc:OrganizationType |
| j:DeporteeType | nc:PersonType |
| j:EnforcementOfficialType | nc:PersonType |
| j:HearingInvestigatorType | nc:PersonType |
| j:JudicialOfficialType | nc:PersonType |
| j:JurorType | nc:PersonType |
| j:MissingPersonType | nc:PersonType |
| j:OtherInvolvedPersonType | nc:PersonType |
| j:PanelMemberType | nc:PersonType |
| j:ParticipantType | nc:PersonType |
| j:RegisteredOffenderType | nc:PersonType |
| j:StaffMemberType | nc:PersonType |
| j:ToolType | nc:ItemType |
| j:VehicleBranderType | nc:OrganizationType |
| j:WitnessType | nc:PersonType |
| lrn-dev:StudentType | nc:PersonType |
| nc:EquipmentType | nc:ItemType |
| nc:PublicationType | nc:DocumentType |
| nc:ReportType | nc:DocumentType |
| nc:WeaponType | nc:ItemType |
| scr:ScreenedAlienType | im:AlienRoleType |
| scr:ScreeningPersonType | nc:PersonType |

</details>

#### Updates to multi-option role types for persons, organizations, and items

Role types that contained `nc:RoleOfPerson` and `nc:RoleOfOrganization` properties, and optionally `nc:RoleOfItem`, have been updated to extend `nc:EntityType`.

This example from the Justice domain shows multiple `RoleOf` properties replaced by extension from `nc:EntityType`.

```diff
  <xs:complexType name="SubjectType">
    <xs:complexContent>
-     <xs:extension base="structures:ObjectType">
+     <xs:extension base="nc:EntityType">
        <xs:sequence>
-         <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
-         <xs:element ref="nc:RoleOfOrganization" minOccurs="0" maxOccurs="unbounded"/>
          <!-- ... -->
        </xs:sequence>
      </xs:extension>
    </xs:complexContent>
  </xs:complexType>
```

<details markdown="1">
  <summary>Expand to view the list of former role types that now extend `nc:EntityType`</summary>

  <br />

- j:LesseeType
- j:LessorType
- j:LienHolderType
- j:PawnBrokerType
- j:SubjectType
- j:VictimType

</details>

#### Updates to other multi-option role types

Other non-entity multi-option role types have been updated to use the NDR Representation pattern.  Since a type in XML cannot extend multiple parent types, a substitution group is used instead:

- An abstract property ending with the representation term `Representation` is added to the type.
- The former `RoleOf` properties are converted to substitutions for the new abstract `Representation` property.

*Note that this solution is similar to the one above that leverages `nc:EntityType`, which uses the representation pattern to represent an object that could be a person, organization, or item.  In this case, the combination of `RoleOf` properties are unique, so new representation properties have to be created.*

This example from the Justice domain shows multiple `RoleOf` properties replaced by the representation pattern.

```diff
  <xs:complexType name="EvidenceType">
    <xs:complexContent>
      <xs:extension base="structures:ObjectType">
        <xs:sequence>
-         <xs:element ref="nc:RoleOfItem" minOccurs="0" maxOccurs="unbounded"/>
-         <xs:element ref="j:RoleOfBinary" minOccurs="0" maxOccurs="unbounded"/>
-         <xs:element ref="j:RoleOfBiometric" minOccurs="0" maxOccurs="unbounded"/>
+         <xs:element ref="j:EvidenceRepresentation" minOccurs="0" maxOccurs="unbounded"/>
          <xs:element ref="j:EvidenceAmount" minOccurs="0" maxOccurs="unbounded"/>
          <!-- ... -->
        </xs:sequence>
      </xs:extension>
    </xs:complexContent>
  </xs:complexType>

+ <xs:element name="EvidenceBinary" type="nc:BinaryType" substitutionGroup="j:EvidenceRepresentation" />
+ <xs:element name="EvidenceBiometric" type="biom:BiometricDataType" substitutionGroup="j:EvidenceRepresentation" />
+ <xs:element name="EvidenceItem" type="nc:ItemType" substitutionGroup="j:EvidenceRepresentation" />
+ <xs:element name="EvidenceRepresentation" abstract="true" />

- <xs:element name="RoleOfBinary" type="nc:BinaryType" />
- <xs:element name="RoleOfBiometric" type="biom:BiometricDataType" />
  <!-- RoleOfItem is not defined in the Justice domain but is also being removed from Core -->
```

<details markdown="1">
  <summary>Expand to view the list of former role types that now employ the representation pattern</summary>

  <br />

- j:EvidenceType
  - *Previously contained:*
  - nc:RoleOfItem
  - j:RoleOfBinary
  - j:RoleOfBiometric
- mo:TargetType
  - *Previously contained:*
  - nc:RoleOfPerson
  - mo:RoleOfUnit
  - mo:RoleOfFacility

</details>


### Refactored other role components ([niemopen/niem-model#38](https://github.com/niemopen/niem-model/issues/38))

In addition to removing the `RoleOf` construct from the model due to NDR updates, other properties and types using the `Role` representation term were reviewed and updated as appropriate to improve consistency with the rest of the model.

**Renamed remaining RoleOf properties and types**

Renamed additional properties and types that were using `RoleOf` as the class term but were not using the `RoleOf` construct as defined by the NDR:

Component | Original name | Updated name
--------- | ------------- | ------------
Property | it:RoleOfCategory | it:PartyIDCategory
Property | it:RoleOfCategoryDescriptionText | it:PartyRoleCategoryDescriptionText
Property | it:RoleOfOrganizationCategoryDescriptionText | it:OrganizationRoleCategoryDescriptionText
Property | it:RoleOfOrganizationCategory | it:OrganizationRoleCategory
Property | it:RoleOfOrganizationCategoryAugmentationPoint | it:OrganizationRoleCategoryAugmentationPoint
Type | it:RoleOfOrganizationCategoryType | it:OrganizationRoleCategoryType

**Removed the Role representation term**

Removed extraneous `Role` representation terms from a list of properties and their corresponding types and augmentation point properties.  For example, `im:AlienRole` has been renamed `im:Alien`.

The following properties have been renamed:

- im:AlienExchangeVisitorRole
- im:AlienRole
- im:AlienStudentRole
- im:CitizenRole
- im:ForeignBornChildOfCitizenRole
- im:ImmigrantRole
- im:LawfulPermanentResidentRole
- im:NationalRole
- im:NaturalizedCitizenRole
- im:NonImmigrantRole
- im:PersonCountryRole
- im:OtherAlienRole
- im:ResidentRole

**Refactored im:PersonCountryRoleType**

Refactored `im:PersonCountryRoleType` to make immigration status more widely available for reuse:

- Moved `im:ImmigrationStatus` from `im:PersonCountryRoleType` to `im:PersonAugmentationType`, making it available wherever `nc:PersonType` is used.
- Updated `im:PersonCountryRoleType` to extend `nc:PersonType`.

**Refactored scr:PersonRole**

- Added a new Screening augmentation for `nc:PersonType`.
- Moved `scr:PersonRole` from `scr:ScreeningPersonType` to the new augmentation.
- Removed properties `scr:AgentPersonRole`, `scr:AgentAssociation`, and type `scr:AgentAssociationType` as they are no longer needed to relate an agent to a role.
