### PR TITLE
Added pronouns to nc:PersonType

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,3 +271,16 @@ Refactored `im:PersonCountryRoleType` to make immigration status more widely ava
 - Added a new Screening augmentation for `nc:PersonType`.
 - Moved `scr:PersonRole` from `scr:ScreeningPersonType` to the new augmentation.
 - Removed properties `scr:AgentPersonRole`, `scr:AgentAssociation`, and type `scr:AgentAssociationType` as they are no longer needed to relate an agent to a role.
+
+### Add pronouns to nc:PersonType ([niemopen/niem-model#15](https://github.com/niemopen/niem-model/issues/15))
+
+Add a substitution group with code and text substitutions for personal pronouns to `nc:PersonType`.
+
+Code set:
+
+- she/her
+- he/him
+- they/them
+- other
+- prefer not to share
+- unknown

--- a/xsd/niem-core.xsd
+++ b/xsd/niem-core.xsd
@@ -3674,6 +3674,53 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  <xs:simpleType name="PersonPronounsCodeSimpleType">
+    <xs:annotation>
+      <xs:documentation>A data type for a set of third-person pronouns that can be used in place of a person's name.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="he/him">
+        <xs:annotation>
+          <xs:documentation>he/him</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="other">
+        <xs:annotation>
+          <xs:documentation>other</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="prefer not to say">
+        <xs:annotation>
+          <xs:documentation>prefer not to say</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="she/her">
+        <xs:annotation>
+          <xs:documentation>she/her</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="they/them">
+        <xs:annotation>
+          <xs:documentation>they/them</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="unknown">
+        <xs:annotation>
+          <xs:documentation>unknown</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="PersonPronounsCodeType">
+    <xs:annotation>
+      <xs:documentation>A data type for a set of third-person pronouns that can be used in place of a person's name.</xs:documentation>
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="nc:PersonPronounsCodeSimpleType">
+        <xs:attributeGroup ref="structures:SimpleObjectAttributeGroup"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
   <xs:complexType name="PersonResidenceAssociationType">
     <xs:annotation>
       <xs:documentation>A data type for an association between a person and a location where that person lives.</xs:documentation>
@@ -3754,6 +3801,7 @@
           <xs:element ref="nc:PersonPhysicalDisabilityText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PersonPhysicalFeature" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PersonPrimaryLanguage" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:PersonPronounsAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PersonRaceAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PersonReligionAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PersonResidentAbstract" minOccurs="0" maxOccurs="unbounded"/>
@@ -11639,6 +11687,21 @@
   <xs:element name="PersonPrimaryWorkerAssociation" type="nc:PersonWorkerAssociationType" nillable="true">
     <xs:annotation>
       <xs:documentation>An association between a person and a primary worker assigned to that person.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="PersonPronounsAbstract" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A data concept for a set of third-person pronouns that can be used in place of a person's name.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="PersonPronounsCode" type="nc:PersonPronounsCodeType" substitutionGroup="nc:PersonPronounsAbstract" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A set of third-person pronouns that can be used in place of a person's name.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="PersonPronounsText" type="nc:TextType" substitutionGroup="nc:PersonPronounsAbstract" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A set of third-person pronouns that can be used in place of a person's name.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="PersonRaceAbstract" abstract="true">


### PR DESCRIPTION
Add a substitution group with code and text substitutions for personal pronouns to `nc:PersonType`.

Code set:

- she/her
- he/him
- they/them
- other
- prefer not to share
- unknown
