### PR TITLE
Support reason for no value on simple content; harmonize yes/no/unknown code sets (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,23 @@ NIEM is now an OASIS Open Project.  URIs for each namespace have been updated to
 <!-- URI for NIEM Core for 6.0 -->
 <xs:schema targetNamespace="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/" ...>
 ```
+
+## Key content changes
+
+The following is a summary of the key changes made in this release.  More details are available from the [6.0 issues list](https://github.com/niemopen/niem-model/labels/6.0) in the NIEM Model issue tracker, and the change log spreadsheet in the release package.
+
+### Support specifying empty value reason on simple values ([niemopen/niem-model#34](https://github.com/niemopen/niem-model/issues/34))
+
+Created the following new attributes and added them to `nc:TextType` and `nc:QuantityType`:
+
+- `nc:valueEmptyReasonCode` of type `nc:EmptyReasonCodeSimpleType`
+- `nc:valueEmptyReasonText` of type `xs:string`
+
+*These new attributes can also be used throughout the model with the new support for attribute wildcards in NIEM 6.0.*
+
+Harmonized two domain code sets that represented a ternary choice with "Yes", "No", and "Unknown" code values with new code `nc:YesNoUnknownCodeType`:
+
+- `em:TernaryIndicatorCodeType`
+- `hs:JuvenileFamilyFinancialProblemCodeType`
+
+*This new code set can be used in places where a boolean with a null value cannot be used to indicate the value is unknown or not applicable.*

--- a/xsd/domains/emergencyManagement.xsd
+++ b/xsd/domains/emergencyManagement.xsd
@@ -7215,38 +7215,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:simpleType name="TernaryIndicatorCodeSimpleType">
-    <xs:annotation>
-      <xs:documentation>A data type for a Ternary Indicator</xs:documentation>
-    </xs:annotation>
-    <xs:restriction base="xs:token">
-      <xs:enumeration value="No">
-        <xs:annotation>
-          <xs:documentation>No</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
-      <xs:enumeration value="Unknown">
-        <xs:annotation>
-          <xs:documentation>Unknown</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
-      <xs:enumeration value="Yes">
-        <xs:annotation>
-          <xs:documentation>Yes</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:complexType name="TernaryIndicatorCodeType">
-    <xs:annotation>
-      <xs:documentation>A data type for a Ternary Indicator code (Yes, No, Unknown)</xs:documentation>
-    </xs:annotation>
-    <xs:simpleContent>
-      <xs:extension base="em:TernaryIndicatorCodeSimpleType">
-        <xs:attributeGroup ref="structures:SimpleObjectAttributeGroup"/>
-      </xs:extension>
-    </xs:simpleContent>
-  </xs:complexType>
   <xs:complexType name="TestAugmentationType">
     <xs:annotation>
       <xs:documentation>A data type for additional information about a test.</xs:documentation>
@@ -12870,7 +12838,7 @@
       <xs:documentation>A data concept for a code list for identification information types for a resource e.g.  ID card number etc.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="ImmediateNeedsTernaryIndicatorCode" type="em:TernaryIndicatorCodeType" nillable="true">
+  <xs:element name="ImmediateNeedsTernaryIndicatorCode" type="nc:YesNoUnknownCodeType" nillable="true">
     <xs:annotation>
       <xs:documentation>An indication if there are immediate needs (Yes, No, Unknown)</xs:documentation>
     </xs:annotation>

--- a/xsd/domains/hs.xsd
+++ b/xsd/domains/hs.xsd
@@ -2772,38 +2772,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:simpleType name="JuvenileFamilyFinancialProblemCodeSimpleType">
-    <xs:annotation>
-      <xs:documentation>A data type for describing whether a family suffers from financial problems.</xs:documentation>
-    </xs:annotation>
-    <xs:restriction base="xs:token">
-      <xs:enumeration value="No">
-        <xs:annotation>
-          <xs:documentation>No</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
-      <xs:enumeration value="Unknown">
-        <xs:annotation>
-          <xs:documentation>Unknown</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
-      <xs:enumeration value="Yes">
-        <xs:annotation>
-          <xs:documentation>Yes</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:complexType name="JuvenileFamilyFinancialProblemCodeType">
-    <xs:annotation>
-      <xs:documentation>A data type for describing whether a family suffers from financial problems.</xs:documentation>
-    </xs:annotation>
-    <xs:simpleContent>
-      <xs:extension base="hs:JuvenileFamilyFinancialProblemCodeSimpleType">
-        <xs:attributeGroup ref="structures:SimpleObjectAttributeGroup"/>
-      </xs:extension>
-    </xs:simpleContent>
-  </xs:complexType>
   <xs:complexType name="JuvenileFireSettingCaseType">
     <xs:annotation>
       <xs:documentation>A data type for a juvenile firesetting case. This is specific to juveniles.</xs:documentation>
@@ -10252,7 +10220,7 @@
       <xs:documentation>A data concept for expressing the financial problems that a child or youth's family is experiencing.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="JuvenileFamilyFinancialProblemCode" type="hs:JuvenileFamilyFinancialProblemCodeType" substitutionGroup="hs:JuvenileFamilyFinancialProblemAbstract" nillable="true">
+  <xs:element name="JuvenileFamilyFinancialProblemCode" type="nc:YesNoUnknownCodeType" substitutionGroup="hs:JuvenileFamilyFinancialProblemAbstract" nillable="true">
     <xs:annotation>
       <xs:documentation>A description of whether juvenile's family is experiencing financial problems.</xs:documentation>
     </xs:annotation>

--- a/xsd/niem-core.xsd
+++ b/xsd/niem-core.xsd
@@ -4117,6 +4117,8 @@
     <xs:simpleContent>
       <xs:extension base="nc:NumericType">
         <xs:attribute ref="nc:quantityUnitText" use="optional"/>
+        <xs:attribute ref="nc:valueEmptyReasonCode" use="optional"/>
+        <xs:attribute ref="nc:valueEmptyReasonText" use="optional"/>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
@@ -4700,6 +4702,8 @@
       <xs:extension base="niem-xs:string">
         <xs:attribute ref="nc:partialIndicator" use="optional"/>
         <xs:attribute ref="nc:truncationIndicator" use="optional"/>
+        <xs:attribute ref="nc:valueEmptyReasonCode" use="optional"/>
+        <xs:attribute ref="nc:valueEmptyReasonText" use="optional"/>
         <xs:attribute ref="xml:lang" use="optional"/>
       </xs:extension>
     </xs:simpleContent>
@@ -4918,6 +4922,38 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  <xs:simpleType name="YesNoUnknownCodeSimpleType">
+    <xs:annotation>
+      <xs:documentation>A data type for a ternary or three-option indicator representing true/yes, false/no, and unknown.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="No">
+        <xs:annotation>
+          <xs:documentation>No</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="Unknown">
+        <xs:annotation>
+          <xs:documentation>Unknown</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="Yes">
+        <xs:annotation>
+          <xs:documentation>Yes</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="YesNoUnknownCodeType">
+    <xs:annotation>
+      <xs:documentation>A data type for a ternary or three-option indicator representing true/yes, false/no, and unknown.</xs:documentation>
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="nc:YesNoUnknownCodeSimpleType">
+        <xs:attributeGroup ref="structures:SimpleObjectAttributeGroup"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
   <xs:simpleType name="ZuluDateTimeSimpleType">
     <xs:annotation>
       <xs:documentation>A data type for a dateTime constrained to always be Zulu time, time at the Zero Meridian.</xs:documentation>
@@ -4978,6 +5014,16 @@
   <xs:attribute name="truncationIndicator" type="xs:boolean">
     <xs:annotation>
       <xs:documentation>True if the length of a string is greater than the length of the field within which the string was stored in the exporting system; false otherwise.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="valueEmptyReasonCode" type="nc:EmptyReasonCodeSimpleType">
+    <xs:annotation>
+      <xs:documentation>A reason why a data value was not provided.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="valueEmptyReasonText" type="xs:string">
+    <xs:annotation>
+      <xs:documentation>A reason why a data value was not provided.</xs:documentation>
     </xs:annotation>
   </xs:attribute>
   <xs:attribute name="yearFirstMonthDate" type="xs:gMonth">


### PR DESCRIPTION
### Support reason for no value and harmonize yes/no/unknown code sets (#34)

#### New attributes

Created the following new attributes and added them to `nc:TextType` and `nc:QuantityType`:

- `nc:valueEmptyReasonCode` of type `nc:EmptyReasonCodeSimpleType`
- `nc:valueEmptyReasonText` of type `xs:string`

*These new attributes can also be used throughout the model with the new support for attribute wildcards in NIEM 6.0.*

#### Yes/No/Unknown code set

Harmonized two domain code sets that represented a ternary choice with "Yes", "No", and "Unknown" code values with new code `nc:YesNoUnknownCodeType`:

- `em:TernaryIndicatorCodeType`
- `hs:JuvenileFamilyFinancialProblemCodeType`

The MilOps USMTF type `usmtf:PositiveNegativeCodeSimpleType` also shares a very similar code set and may be able to be leverage the new type in Core in the future during upcoming USMTF harmonization efforts.

*This new code set can be used in places where a boolean with a null value cannot be used to indicate the value is unknown or not applicable.*
