### PR TITLE
Update CBRN domain content

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,16 @@ CBRN defines two metadata elements that have type `structures:MetadataType`:
 The `structures:MetadataType` does not carry content and is not meant to be used directly as a type of a property.
 
 Updated these two properties to have type `nc:MetadataType`.
+
+#### Refactored cbrn:ReportType into an augmentation of nc:ReportType ([niemopen/niem-model#11](https://github.com/niemopen/niem-model/issues/11))
+
+Refactored the following in `cbrn:ReportType`:
+
+- `cbrn:ReportDateTime`
+- `cbrn:CredentialsAuthenticationAbstract`
+- `nc:ActivityName`
+- `cbrn:ReportAugmentationPoint`
+
+into an augmentation of `nc:ReportType`, making these properties more reusable.
+
+Removed property `cbrn:ReportDateTime` ("A DateTime when a report was created.") as it is no longer needed with `nc:DocumentCreationDate` available through `nc:DocumentType`, the parent type of `nc:ReportType`.

--- a/README.md
+++ b/README.md
@@ -24,3 +24,14 @@ NIEM is now an OASIS Open Project.  URIs for each namespace have been updated to
 <!-- URI for NIEM Core for 6.0 -->
 <xs:schema targetNamespace="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/" ...>
 ```
+
+#### Updated CBRN CaseMetadata and DataFileMetadata to have type nc:MetadataType ([niemopen/niem-model#24](https://github.com/niemopen/niem-model/issues/24))
+
+CBRN defines two metadata elements that have type `structures:MetadataType`:
+
+- `cbrn:CaseMetadata`
+- `cbrn:DataFileMetadata`, which are both of type structures:MetadataType.
+
+The `structures:MetadataType` does not carry content and is not meant to be used directly as a type of a property.
+
+Updated these two properties to have type `nc:MetadataType`.

--- a/xsd/domains/cbrn.xsd
+++ b/xsd/domains/cbrn.xsd
@@ -1674,17 +1674,15 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="ReportType">
+  <xs:complexType name="ReportAugmentationType">
     <xs:annotation>
-      <xs:documentation>A data type for a report provided on an unsolicited basis; i.e., not in response to a request message (Pull), but by Push from the entity providing the report.</xs:documentation>
+      <xs:documentation>A data type for additional information about a report.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="structures:AugmentationType">
         <xs:sequence>
-          <xs:element ref="cbrn:ReportDateTime" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="cbrn:CredentialsAuthenticationAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:ActivityName" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="cbrn:ReportAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -4472,14 +4470,9 @@
       <xs:documentation>A placeholder for comments intended to help the consumer of the data to understand better the information encapsulated by the parent element.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="Report" type="cbrn:ReportType" nillable="true">
+  <xs:element name="ReportAugmentation" type="cbrn:ReportAugmentationType" substitutionGroup="nc:ReportAugmentationPoint" nillable="true">
     <xs:annotation>
-      <xs:documentation>A report provided on an unsolicited basis; i.e., not in response to a request message (Pull), but by Push from the entity providing the report.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="ReportAugmentationPoint" abstract="true">
-    <xs:annotation>
-      <xs:documentation>An augmentation point for cbrn:ReportType.</xs:documentation>
+      <xs:documentation>Additional information about a report.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="ReportDateTime" type="niem-xs:dateTime" nillable="true">

--- a/xsd/domains/cbrn.xsd
+++ b/xsd/domains/cbrn.xsd
@@ -2442,7 +2442,7 @@
       <xs:documentation>A description of the locale or location associated with a case when it was initiated. For a case that is a collection of cases, may describe a route or involved locations/locales.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="CaseMetadata" type="structures:MetadataType" nillable="true">
+  <xs:element name="CaseMetadata" type="nc:MetadataType" nillable="true">
     <xs:annotation>
       <xs:documentation>Metadata about a case.</xs:documentation>
     </xs:annotation>
@@ -2882,7 +2882,7 @@
       <xs:documentation>A time stamp identifying when a data file was last modified.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="DataFileMetadata" type="structures:MetadataType" nillable="true">
+  <xs:element name="DataFileMetadata" type="nc:MetadataType" nillable="true">
     <xs:annotation>
       <xs:documentation>Metadata about data file Security classification and marking attributes.</xs:documentation>
     </xs:annotation>


### PR DESCRIPTION

#### Updated CBRN CaseMetadata and DataFileMetadata to have type nc:MetadataType ([niemopen/niem-model#24](https://github.com/niemopen/niem-model/issues/24))

CBRN defines two metadata elements that have type `structures:MetadataType`:

- `cbrn:CaseMetadata`
- `cbrn:DataFileMetadata`, which are both of type structures:MetadataType.

The `structures:MetadataType` does not carry content and is not meant to be used directly as a type of a property.

Updated these two properties to have type `nc:MetadataType`.

#### Refactored cbrn:ReportType into an augmentation of nc:ReportType ([niemopen/niem-model#11](https://github.com/niemopen/niem-model/issues/11))

Refactored the following in `cbrn:ReportType`:

- `cbrn:ReportDateTime`
- `cbrn:CredentialsAuthenticationAbstract`
- `nc:ActivityName`
- `cbrn:ReportAugmentationPoint`

into an augmentation of `nc:ReportType`, making these properties more reusable.

Removed property `cbrn:ReportDateTime` ("A DateTime when a report was created.") as it is no longer needed with `nc:DocumentCreationDate` available through `nc:DocumentType`, the parent type of `nc:ReportType`.
