### PR TITLE
Harmonized StudentType (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ NIEM is now an OASIS Open Project.  URIs for each namespace have been updated to
 <!-- URI for NIEM Core for 6.0 -->
 <xs:schema targetNamespace="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/" ...>
 ```
+
+#### Harmonized StudentType ([niemopen/niem-model#52](https://github.com/niemopen/niem-model/issues/52))
+
+The Human Services domain and the Learning and Development domain both define type `StudentType`.  Created a new `nc:StudentType` in Core and converted the two domain types to augmentations so student properties from either domain can be used together under the same Core object.
+
+Merged and moved the only overlapping property (`hs:StudentIdentification` / `lrn-dev:StudentID`) into Core as `nc:StudentIdentification`.

--- a/xsd/domains/hs.xsd
+++ b/xsd/domains/hs.xsd
@@ -3929,7 +3929,7 @@
           <xs:element ref="hs:StudentCurrentEducationDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:StudentSpecialEducationEligibleIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:StudentCurrentEducationEnrollmentEndDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="hs:StudentIdentification" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:StudentIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:EducationalIssues" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:HistoricalNarrative" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:ICWAEligibilityIndicator" minOccurs="0" maxOccurs="unbounded"/>
@@ -6122,6 +6122,28 @@
           <xs:element ref="hs:SecondaryOfficialContact" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:Person" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:StateInputAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="StudentAugmentationType">
+    <xs:annotation>
+      <xs:documentation>A data type for additional information about a student.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="structures:AugmentationType">
+        <xs:sequence>
+          <xs:element ref="hs:StudentCurrentEducationGradeLevelAbstract" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="hs:StudentCurrentEducationDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="hs:StudentCurrentEducationEnrollmentIndicator" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="hs:StudentCurrentEducationEnrollmentEndDate" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="hs:StudentCurrentEducationTruancyIndicator" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="hs:EducationalIssues" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="hs:EducationalAdjustmentAbstract" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="hs:StudentSpecialEducationEligibleIndicator" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="hs:StudentSpecialEducationDetails" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="hs:StudentSchoolConductChangeText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="hs:StudentPhotoImage" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -12157,14 +12179,9 @@
       <xs:documentation>An association between a child and a person who is in a Person Union with one of the child's biological parents.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="Student" type="hs:StudentType" nillable="true">
+  <xs:element name="StudentAugmentation" type="hs:StudentAugmentationType" substitutionGroup="nc:StudentAugmentationPoint" nillable="true">
     <xs:annotation>
-      <xs:documentation>A role of a K-12 student, played by a juvenile.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="StudentAugmentationPoint" abstract="true">
-    <xs:annotation>
-      <xs:documentation>An augmentation point for StudentType.</xs:documentation>
+      <xs:documentation>Additional information about a student.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="StudentCurrentEducationDescriptionText" type="nc:TextType" nillable="true">
@@ -12200,11 +12217,6 @@
   <xs:element name="StudentCurrentEducationTruancyIndicator" type="niem-xs:boolean" nillable="true">
     <xs:annotation>
       <xs:documentation>True if the juvenile is currently considered truant; false otherwise.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="StudentIdentification" type="nc:IdentificationType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A unique alphanumeric identification assigned to a student by an education organization.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="StudentPhotoImage" type="nc:ImageType" nillable="true">

--- a/xsd/domains/learn-dev.xsd
+++ b/xsd/domains/learn-dev.xsd
@@ -259,15 +259,13 @@
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
-  <xs:complexType name="StudentType">
+  <xs:complexType name="StudentAugmentationType">
     <xs:annotation>
-      <xs:documentation>A data type for a person formally engaged in learning, especially one enrolled in a school or college.</xs:documentation>
+      <xs:documentation>A data type for additional information about a student.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
+      <xs:extension base="structures:AugmentationType">
         <xs:sequence>
-          <xs:element ref="nc:RoleOfPerson" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="lrn-dev:StudentID" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="lrn-dev:StudentIdentificationSystemName" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="lrn-dev:PersonGeneralIntelligenceText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="lrn-dev:PersonIntelligenceTest" minOccurs="0" maxOccurs="unbounded"/>
@@ -284,7 +282,6 @@
           <xs:element ref="lrn-dev:PersonMetacognitionTest" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="lrn-dev:PersonWorkingMemoryCapacityTest" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="lrn-dev:PersonCognitiveFlexibilityTest" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="lrn-dev:StudentAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -744,19 +741,9 @@
       <xs:documentation>A cognitive system that stores information in an accessible state for utilization in complex mental tasks. Currently, the Wechsler Adult Intelligence Scale, 3rd edition (WAIS-III) is the most commonly used instrument in the armamentarium of clinical neuropsychologists (Camara et al., 2000; Rabin, Barr, &amp; Burton 2005). Therefore, the Working Memory Index (WMI) from that battery is commonly used to assess working memory ability.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="Student" type="lrn-dev:StudentType" nillable="true">
+  <xs:element name="StudentAugmentation" type="lrn-dev:StudentAugmentationType" substitutionGroup="nc:StudentAugmentationPoint" nillable="true">
     <xs:annotation>
-      <xs:documentation>A person formally engaged in learning, especially one enrolled in a school or college.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="StudentAugmentationPoint" abstract="true">
-    <xs:annotation>
-      <xs:documentation>An augmentation point for type StudentType</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="StudentID" type="niem-xs:string" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A unique identifier number or alphanumeric code assigned to a student by a school, school system, a state, or other agency or entity.</xs:documentation>
+      <xs:documentation>Additional information about a student.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="StudentIdentificationSystemName" type="nc:TextType" nillable="true">

--- a/xsd/niem-core.xsd
+++ b/xsd/niem-core.xsd
@@ -4544,6 +4544,19 @@
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
+  <xs:complexType name="StudentType">
+    <xs:annotation>
+      <xs:documentation>A data type for a person formally engaged in learning, especially one enrolled in a school or college.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="nc:PersonType">
+        <xs:sequence>
+          <xs:element ref="nc:StudentIdentification" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:StudentAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
   <xs:complexType name="SubstanceMeasureType">
     <xs:annotation>
       <xs:documentation>A data type for a measure of the amount of something.</xs:documentation>
@@ -13303,6 +13316,21 @@
   <xs:element name="StreetPredirectional" type="nc:StreetDirectionalType" nillable="true">
     <xs:annotation>
       <xs:documentation>A direction that appears before a street name.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="Student" type="nc:StudentType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A person formally engaged in learning, especially one enrolled in a school or college.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="StudentAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for type nc:StudentType</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="StudentIdentification" type="nc:IdentificationType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A unique alphanumeric identification assigned to a student by an education organization.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="SubFacility" type="nc:FacilityType" nillable="true">


### PR DESCRIPTION
The Human Services domain and the Learning and Development domain both define type `StudentType`:

<details markdown="1">
  <summary>Expand to see hs:StudentType</summary>
<br />

- hs:StudentCurrentEducationGradeLevelAbstract
- hs:StudentCurrentEducationDescriptionText
- hs:StudentCurrentEducationEnrollmentIndicator
- hs:StudentCurrentEducationEnrollmentEndDate
- hs:StudentCurrentEducationTruancyIndicator
- hs:EducationalIssues
- hs:EducationalAdjustmentAbstract
- hs:StudentSpecialEducationEligibleIndicator
- hs:StudentSpecialEducationDetails
- hs:StudentSchoolConductChangeText
- hs:StudentIdentification
- hs:StudentPhotoImage
</details>


<details markdown="1">
  <summary>Expand to see lrn-dev:StudentType</summary>
<br />

- lrn-dev:StudentID
- lrn-dev:StudentIdentificationSystemName
- lrn-dev:PersonGeneralIntelligenceText
- lrn-dev:PersonIntelligenceTest
- lrn-dev:PersonGeneralCognitiveAbilityText
- lrn-dev:PersonSATScoreValue
- lrn-dev:PersonACTScoreValue
- lrn-dev:PersonWordFluencyText
- lrn-dev:PersonVerbalComprehensionText
- lrn-dev:PersonNumericalAbilityText
- lrn-dev:PersonSpatialVisualizationText
- lrn-dev:PersonPerceptualSpeedText
- lrn-dev:PersonMemoryText
- lrn-dev:PersonInductiveReasoningText
- lrn-dev:PersonMetacognitionTest
- lrn-dev:PersonWorkingMemoryCapacityTest
- lrn-dev:PersonCognitiveFlexibilityTest

</details>

### Updates

Created a new `nc:StudentType` in Core and converted the two domain types to augmentations so student properties from either domain can be used together under the same Core object.

Merged and moved the only overlapping property (`hs:StudentIdentification` / `lrn-dev:StudentID`) into Core as `nc:StudentIdentification`.
