### PR TITLE
Added attribute augmentations for nc:Metadata and cui:PortionMarkingMetadata (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,47 @@ NIEM is now an OASIS Open Project.  URIs for each namespace have been updated to
 <!-- URI for NIEM Core for 6.0 -->
 <xs:schema targetNamespace="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/" ...>
 ```
+
+### Added attribute augmentations for nc:Metadata and cui:PortionMarkingMetadata ([niemopen/niem-model#46](https://github.com/niemopen/niem-model/issues/46))
+
+The NDR is removing support for the `structures:metadata` and `structures:relationshipMetadata` attributes.  Metadata properties can now be added to class types directly, via augmentation, or via extension.
+
+For data types (representing a value, like a string or a number), element metadata properties cannot be attached directly.  Instead, the NDR will now support attribute augmentations, which allow attributes to be created with representation term `Ref` and type `xs:IDREFS`.  This XML Schema type allows a set of space-delimited xs:IDREF values, or pointers in XML.
+
+Example schema changes from Core:
+
+```diff
++ <xs:attribute name="portionMarkingMetadataRef" type="xs:IDREFS">
++   <xs:annotation>
++     <xs:documentation>An attribute reference to cui:PortionMarkingMetadata.</xs:documentation>
++   </xs:annotation>
++ </xs:attribute>
+
+  <xs:element name="PortionMarkingMetadata" type="cui:PortionMarkingMetadataType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>Metadata about the Controlled Unclassified Information
+       (CUI) portion marking of a document.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+```
+
+Example usage in a message:
+
+```diff
+<my:Message>
+  <nc:Person>
+    <nc:PersonName>
+-     <nc:PersonSurName structures:metadata="P01">Smith</nc:PersonSurName>
++     <nc:PersonSurName cui:portionMarkingMetadataRef="P01">Smith</nc:PersonSurName>
+    </nc:PersonName>
+  </nc:Person>
+
+  <cui:PortionMarkingMetadata structures:id="M01">
+    <!-- ... -->
+  </cui:PortionMarkingMetadata>
+</my:Message>
+```
+
+The `structures` metadata attributes were very generic and did not convey what kind of information should be referenced.  These new attribute augmentations have semantic names, making the requirements of a message specification clearer.
+
+This approach should be used along with the new support for attribute wildcards in the `structures` schema, allowing message designers to attach declared attributes to NIEM-conformant complex types (classes or complex data types).

--- a/xsd/auxiliary/cui.xsd
+++ b/xsd/auxiliary/cui.xsd
@@ -1019,6 +1019,11 @@
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
+  <xs:attribute name="portionMarkingMetadataRef" type="xs:IDREFS">
+    <xs:annotation>
+      <xs:documentation>An attribute reference to cui:PortionMarkingMetadata.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
   <xs:element name="BasicCategoryMarkingCode" type="cui:BasicCategoryMarkingCodeType" nillable="true">
     <xs:annotation>
       <xs:documentation>A Controlled Unclassified Information (CUI) category for which the authorizing law, regulation, or Government-wide policy does not set out specific handling or dissemination controls.</xs:documentation>

--- a/xsd/niem-core.xsd
+++ b/xsd/niem-core.xsd
@@ -4698,6 +4698,7 @@
     </xs:annotation>
     <xs:simpleContent>
       <xs:extension base="niem-xs:string">
+        <xs:attribute ref="nc:metadataRef" use="optional"/>
         <xs:attribute ref="nc:partialIndicator" use="optional"/>
         <xs:attribute ref="nc:truncationIndicator" use="optional"/>
         <xs:attribute ref="xml:lang" use="optional"/>
@@ -4943,6 +4944,11 @@
   <xs:attribute name="fiscalYearStartDate" type="xs:date">
     <xs:annotation>
       <xs:documentation>A date on which a fiscal year begins.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="metadataRef" type="xs:IDREFS">
+    <xs:annotation>
+      <xs:documentation>An attribute reference to nc:Metadata.</xs:documentation>
     </xs:annotation>
   </xs:attribute>
   <xs:attribute name="partialIndicator" type="xs:boolean">


### PR DESCRIPTION
The NDR is removing support for the `structures:metadata` and `structures:relationshipMetadata` attributes.  Metadata properties can now be added to class types directly, via augmentation, or via extension.

For data types (representing a value, like a string or a number), element metadata properties cannot be attached directly.  Instead, the NDR will now support attribute augmentations, which allow attributes to be created with representation term `Ref` and type `xs:IDREFS`.  This XML Schema type allows a set of space-delimited xs:IDREF values, or pointers in XML.

Example schema changes from Core:

```diff
+ <xs:attribute name="portionMarkingMetadataRef" type="xs:IDREFS">
+   <xs:annotation>
+     <xs:documentation>An attribute reference to cui:PortionMarkingMetadata.</xs:documentation>
+   </xs:annotation>
+ </xs:attribute>

  <xs:element name="PortionMarkingMetadata" type="cui:PortionMarkingMetadataType" nillable="true">
    <xs:annotation>
      <xs:documentation>Metadata about the Controlled Unclassified Information
       (CUI) portion marking of a document.</xs:documentation>
    </xs:annotation>
  </xs:element>
```

Example usage in a message:

```diff
<my:Message>
  <nc:Person>
    <nc:PersonName>
-     <nc:PersonSurName structures:metadata="P01">Smith</nc:PersonSurName>
+     <nc:PersonSurName cui:portionMarkingMetadataRef="P01">Smith</nc:PersonSurName>
    </nc:PersonName>
  </nc:Person>

  <cui:PortionMarkingMetadata structures:id="M01">
    <!-- ... -->
  </cui:PortionMarkingMetadata>
</my:Message>
```

The `structures` metadata attributes were very generic and did not convey what kind of information should be referenced.  These new attribute augmentations have semantic names, making the requirements of a message specification clearer.

This approach should be used along with the new support for attribute wildcards in the `structures` schema, allowing message designers to attach declared attributes to NIEM-conformant complex types (classes or complex data types).
