### PR TITLE
Refactored metadata as regular NIEM components (niemopen/niem-naming-design-rules#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,53 @@ NIEM is now an OASIS Open Project.  URIs for each namespace have been updated to
 <!-- URI for NIEM Core for 6.0 -->
 <xs:schema targetNamespace="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/" ...>
 ```
+
+## Refactored metadata as regular NIEM components ([niemopen/niem-naming-design-rules#8](https://github.com/niemopen/niem-naming-design-rules/issues/8))
+
+**NDR changes now treat metadata components like regular components:**
+
+- Metadata types can use type extension
+- Metadata types must support augmentation
+- Metadata properties may be contained in other types
+
+**Leveraged type extension for the following types:**
+
+- `scr:PersonMetadataType` now extends `nc:MetadataType`
+
+**Created augmentation points for the following metadata types:**
+
+- `nc:MetadataType`
+- `cbrn:TotalDoseMetadataType`
+- `cbrn:TotalExposureMetadataType`
+- `cui:DocumentMarkingMetadataType`
+- `cui:PortionMarkingMetadataType`
+- `mo:ImplementationSpecificSettingMetadataType`
+- `mo:MinimumEssentialMetadataType`
+- `mo:UncertaintyMetadataType`
+- `scr:PersonMetadataType`
+
+**Converted the following metadata types to augmentations of `nc:MetadataType`:**
+
+- `hs:MetadataType`
+- `j:MetadataType`
+
+**Added the following metadata properties to types:**
+
+- `cbrn:totalDoseMetadataRef`
+  - Added to type `cbrn:TotalDoseuSvType` as a metadata attribute augmentation
+- `cbrn:totalExposureMetadataRef`
+  - Added to type `cbrn:TotalExposuremRType` as a metadata attribute augmentation
+- `cui:DocumentMarkingMetadata`
+  - Added to type `cui:DocumentAugmentationType`
+  - Added to type `cui:ReportAugmentationType`
+  - Added to type `cui:MessageAugmentationType`
+- `mo:ImplementationSpecificSettingMetadata`
+  - Added to type `mo:SettingType`
+- `mo:MinimumEssentialMetadata`
+  - Added to type `mo:DocumentAugmentationType`
+  - Added to type `mo:ReportAugmentationType`
+  - Added to type `mo:MessageAugmentationType`
+- `mo:UncertaintyMetadata`
+  - Added to type `mo:MeasureAugmentationType`
+- `scr:PersonMetadata`
+  - Added to type `scr:PersonAugmentationType`

--- a/xsd/auxiliary/cui.xsd
+++ b/xsd/auxiliary/cui.xsd
@@ -479,6 +479,18 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  <xs:complexType name="DocumentAugmentationType">
+    <xs:annotation>
+      <xs:documentation>A data type for additional information about a document.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="structures:AugmentationType">
+        <xs:sequence>
+          <xs:element ref="cui:DocumentMarkingMetadata" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
   <xs:simpleType name="DocumentMarkingLDCCodeSimpleType">
     <xs:annotation>
       <xs:documentation>A data type for a Controlled Unclassified Information (CUI) Executive Agent-approved control that agencies may use to limit or specify CUI dissemination.</xs:documentation>
@@ -575,6 +587,19 @@
           <xs:element ref="cui:DecontrolSchedule" minOccurs="0" maxOccurs="1"/>
           <xs:element ref="cui:RequiredIndicatorsText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="cui:SupplementalAdministrativeMarkingAbstract" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="cui:DocumentMarkingMetadataAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="MessageAugmentationType">
+    <xs:annotation>
+      <xs:documentation>A data type for additional information about a message.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="structures:AugmentationType">
+        <xs:sequence>
+          <xs:element ref="cui:DocumentMarkingMetadata" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -671,6 +696,19 @@
           <xs:element ref="cui:SpecifiedCategoryMarkingCode" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="cui:BasicCategoryMarkingCode" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="cui:PortionMarkingLDC" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="cui:PortionMarkingMetadataAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="ReportAugmentationType">
+    <xs:annotation>
+      <xs:documentation>A data type for additional information about a report.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="structures:AugmentationType">
+        <xs:sequence>
+          <xs:element ref="cui:DocumentMarkingMetadata" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -1054,6 +1092,11 @@
       <xs:documentation>A CUI Designation Indicator. Must include the designator's agency and may take any form that identifies the designating agency.</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="DocumentAugmentation" type="cui:DocumentAugmentationType" substitutionGroup="nc:DocumentAugmentationPoint" nillable="true">
+    <xs:annotation>
+      <xs:documentation>Additional information about a document.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="DocumentMarkingLDC" type="cui:DocumentMarkingLDCType" nillable="true">
     <xs:annotation>
       <xs:documentation>A document marking for a Controlled Unclassified Information (CUI) Executive Agent-approved control that agencies may use to limit or specify CUI dissemination.</xs:documentation>
@@ -1074,6 +1117,11 @@
       <xs:documentation>Metadata about Controlled Unclassified Information (CUI) marking of a document.</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="DocumentMarkingMetadataAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for cui:DocumentMarkingMetadataType.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="LDC-DLONLYText" type="nc:TextType" nillable="true">
     <xs:annotation>
       <xs:documentation>A list of individuals, organizations, or entities for which dissemination is authorized.</xs:documentation>
@@ -1087,6 +1135,11 @@
   <xs:element name="LDCForeignDisclosureToAbstract" abstract="true">
     <xs:annotation>
       <xs:documentation>A data concept for a foreign country/international organization approved for the release or disclosure of classified information, for use with REL TO and DISPLAY ONLY limited dissemination controls for Controlled Unclassified Information (CUI).</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="MessageAugmentation" type="cui:MessageAugmentationType" substitutionGroup="nc:MessageAugmentationPoint" nillable="true">
+    <xs:annotation>
+      <xs:documentation>Additional information about a message.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="PortionMarkingLDC" type="cui:PortionMarkingLDCType" nillable="true">
@@ -1107,6 +1160,16 @@
   <xs:element name="PortionMarkingMetadata" type="cui:PortionMarkingMetadataType" nillable="true">
     <xs:annotation>
       <xs:documentation>Metadata about the Controlled Unclassified Information (CUI) portion marking of a document.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="PortionMarkingMetadataAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for cui:PortionMarkingMetadataType.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="ReportAugmentation" type="cui:ReportAugmentationType" substitutionGroup="nc:ReportAugmentationPoint" nillable="true">
+    <xs:annotation>
+      <xs:documentation>Additional information about a report.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="RequiredIndicatorsText" type="nc:TextType" nillable="true">

--- a/xsd/domains/cbrn.xsd
+++ b/xsd/domains/cbrn.xsd
@@ -1980,6 +1980,7 @@
         <xs:sequence>
           <xs:element ref="cbrn:RadRawTotalDoseValue" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="cbrn:RadDetectorInformation" minOccurs="0" maxOccurs="1"/>
+          <xs:element ref="cbrn:TotalDoseMetadataAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -1998,6 +1999,7 @@
     </xs:annotation>
     <xs:simpleContent>
       <xs:extension base="cbrn:NonNegativeDoubleType">
+        <xs:attribute ref="cbrn:totalDoseMetadataRef" use="optional"/>
         <xs:attribute ref="cbrn:unitsText" use="required"/>
       </xs:extension>
     </xs:simpleContent>
@@ -2011,6 +2013,7 @@
         <xs:sequence>
           <xs:element ref="cbrn:RadDetectorInformation" minOccurs="0" maxOccurs="1"/>
           <xs:element ref="cbrn:RadRawTotalExposureValue" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="cbrn:TotalExposureMetadataAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -2021,6 +2024,7 @@
     </xs:annotation>
     <xs:simpleContent>
       <xs:extension base="cbrn:NonNegativeDoubleType">
+        <xs:attribute ref="cbrn:totalExposureMetadataRef" use="optional"/>
         <xs:attribute ref="cbrn:unitsText" use="required"/>
       </xs:extension>
     </xs:simpleContent>
@@ -2125,6 +2129,16 @@
   <xs:attribute name="systemSimulatedIndicator" type="xs:boolean">
     <xs:annotation>
       <xs:documentation>True if the system is simulated; false otherwise.  If the attribute is not present, the value is false.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="totalDoseMetadataRef" type="xs:IDREFS">
+    <xs:annotation>
+      <xs:documentation>An attribute reference to cbrn:totalDoseMetadataRef.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="totalExposureMetadataRef" type="xs:IDREFS">
+    <xs:annotation>
+      <xs:documentation>An attribute reference to cbrn:totalExposureMetadataRef.</xs:documentation>
     </xs:annotation>
   </xs:attribute>
   <xs:attribute name="unitsText" type="xs:token">
@@ -4877,6 +4891,11 @@
       <xs:documentation>Metadata about the accumulated ambient dose equivalent since the last radiation detection instrument reset, with units microsieverts (Sv).</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="TotalDoseMetadataAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for cbrn:TotalDoseMetadataType.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="TotalDoseNumeric" type="cbrn:TotalDoseType" nillable="true">
     <xs:annotation>
       <xs:documentation>A value for the accumulated ambient dose equivalent since the last radiation detection instrument reset, in microsieverts (Sv).</xs:documentation>
@@ -4895,6 +4914,11 @@
   <xs:element name="TotalExposureMetadata" type="cbrn:TotalExposureMetadataType" nillable="true" appinfo:appliesToTypes="structures:ObjectType">
     <xs:annotation>
       <xs:documentation>Metadata about accumulated exposure since the last instrument reset, in milliroentgen (mR).</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="TotalExposureMetadataAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for cbrn:TotalExposureMetadataType.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="TotalExposureNumeric" type="cbrn:TotalExposureType" nillable="true">

--- a/xsd/domains/hs.xsd
+++ b/xsd/domains/hs.xsd
@@ -3445,12 +3445,12 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="MetadataType">
+  <xs:complexType name="MetadataAugmentationType">
     <xs:annotation>
-      <xs:documentation>A data type for metadata about a record.</xs:documentation>
+      <xs:documentation>A data type for additional information about metadata.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:MetadataType">
+      <xs:extension base="structures:AugmentationType">
         <xs:sequence>
           <xs:element ref="hs:CreationDate" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="hs:LastUpdatedTrackingID" minOccurs="0" maxOccurs="unbounded"/>
@@ -10772,9 +10772,9 @@
       <xs:documentation>A description of past in-patient hospitalizations due to mental health issues.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="Metadata" type="hs:MetadataType" nillable="true">
+  <xs:element name="MetadataAugmentation" type="hs:MetadataAugmentationType" substitutionGroup="nc:MetadataAugmentationPoint" nillable="true">
     <xs:annotation>
-      <xs:documentation>Information that further qualifies primary juvenile data; data about data. A typical use is internal tracking IDs.</xs:documentation>
+      <xs:documentation>Additional information about metadata.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="MethodOfPaymentAbstract" abstract="true">

--- a/xsd/domains/jxdm.xsd
+++ b/xsd/domains/jxdm.xsd
@@ -5574,12 +5574,12 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="MetadataType">
+  <xs:complexType name="MetadataAugmentationType">
     <xs:annotation>
-      <xs:documentation>A data type for information that further qualifies the kind of data represented.</xs:documentation>
+      <xs:documentation>A data type for additional information about metadata.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:MetadataType">
+      <xs:extension base="structures:AugmentationType">
         <xs:sequence>
           <xs:element ref="j:CriminalInformationIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:IntelligenceInformationIndicator" minOccurs="0" maxOccurs="unbounded"/>
@@ -21081,9 +21081,9 @@
       <xs:documentation>True if the parolee requests independent evaluations to determine if the parolee meets the requirements of the Mentally Disordered Offender law; false otherwise.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="Metadata" type="j:MetadataType" nillable="true" appinfo:appliesToTypes="structures:AssociationType structures:ObjectType">
+  <xs:element name="MetadataAugmentation" type="j:MetadataAugmentationType" substitutionGroup="nc:MetadataAugmentationPoint" nillable="true">
     <xs:annotation>
-      <xs:documentation>Information that further qualifies the kind of data represented.</xs:documentation>
+      <xs:documentation>Additional information about metadata.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Metal" type="nc:SubstanceType" nillable="true">

--- a/xsd/domains/mo.xsd
+++ b/xsd/domains/mo.xsd
@@ -4759,6 +4759,7 @@
       <xs:extension base="structures:MetadataType">
         <xs:sequence>
           <xs:element ref="mo:JSONEncodedText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="mo:ImplementationSpecificSettingMetadataAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -6506,6 +6507,30 @@
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
+  <xs:complexType name="MeasureAugmentationType">
+    <xs:annotation>
+      <xs:documentation>A data type for additional information about a measure.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="structures:AugmentationType">
+        <xs:sequence>
+          <xs:element ref="mo:UncertaintyMetadata" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="MessageAugmentationType">
+    <xs:annotation>
+      <xs:documentation>A data type for additional information about a message.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="structures:AugmentationType">
+        <xs:sequence>
+          <xs:element ref="mo:MinimumEssentialMetadata" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
   <xs:simpleType name="MGRSCoordinateStringSimpleType">
     <xs:annotation>
       <xs:documentation>A data type for a complete coordinate string from the Military Grid Reference System (MGRS) which represents a location with a Universal Transverse Mercator (UTM) or Universal Polar Stereographic (UPS) coordinate and a unique military grid square.</xs:documentation>
@@ -6865,6 +6890,7 @@
           <xs:element ref="mo:SecurityClassificationInformation" minOccurs="1" maxOccurs="1"/>
           <xs:element ref="mo:DisclosureReleasability" minOccurs="1" maxOccurs="1"/>
           <xs:element ref="mo:HandlingRestrictions" minOccurs="1" maxOccurs="1"/>
+          <xs:element ref="mo:MinimumEssentialMetadataAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -8077,6 +8103,18 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  <xs:complexType name="ReportAugmentationType">
+    <xs:annotation>
+      <xs:documentation>A data type for additional information about a report.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="structures:AugmentationType">
+        <xs:sequence>
+          <xs:element ref="mo:MinimumEssentialMetadata" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
   <xs:complexType name="ResourceFormatType">
     <xs:annotation>
       <xs:documentation>A data type for information about the file format, physical medium, or dimensions of the resource.</xs:documentation>
@@ -8296,6 +8334,7 @@
           <xs:element ref="mo:SettingReadOnlyIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="mo:SettingExclusiveControlIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="mo:SettingDisplayElementAbstract" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="mo:ImplementationSpecificSettingMetadata" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="mo:SettingAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -9170,6 +9209,7 @@
           <xs:element ref="mo:UncertaintyQualityMethodCode" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="mo:UncertaintyQualityStrengthCode" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="mo:UncertaintyComputationMethodAbstract" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="mo:UncertaintyMetadataAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -11139,6 +11179,11 @@
       <xs:documentation>A element for disclosure information.</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="DocumentAugmentation" type="mo:DocumentAugmentationType" substitutionGroup="nc:DocumentAugmentationPoint" nillable="true">
+    <xs:annotation>
+      <xs:documentation>Additional information about a document.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="EffectDuration" type="niem-xs:duration" nillable="true">
     <xs:annotation>
       <xs:documentation>A quantity of time that specifies the length of time which the target is under the influence of the intended effect.</xs:documentation>
@@ -11529,6 +11574,11 @@
       <xs:documentation>Metadata about settings that are specific to an implementation.</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="ImplementationSpecificSettingMetadataAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for mo:ImplementationSpecificSettingMetadataType.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="IndicatorSettingData" type="mo:IndicatorSettingDataType" substitutionGroup="mo:SettingDataRepresentation" nillable="true">
     <xs:annotation>
       <xs:documentation>A setting that is a true or false value</xs:documentation>
@@ -11719,6 +11769,16 @@
       <xs:documentation>A point whose coordinates are the arithmetic means of the coordinates of the separate points of impact/burst of a finite number of projectiles fired or released at the same aiming point under a given set of conditions.</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="MeasureAugmentation" type="mo:MeasureAugmentationType" substitutionGroup="nc:MeasureAugmentationPoint" nillable="true">
+    <xs:annotation>
+      <xs:documentation>Additional information about a measure.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="MessageAugmentation" type="mo:MessageAugmentationType" substitutionGroup="nc:MessageAugmentationPoint" nillable="true">
+    <xs:annotation>
+      <xs:documentation>Additional information about a message.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="MGRSCoordinateAbstract" substitutionGroup="nc:LocationGeospatialCoordinateAbstract" abstract="true">
     <xs:annotation>
       <xs:documentation>A data concept for a coordinate from the Military Grid Reference System (MGRS) which represents a location using the Universal Transverse Mercator (UTM) and the UPS grid systems and a unique military grid labeling convention.</xs:documentation>
@@ -11807,6 +11867,11 @@
   <xs:element name="MinimumEssentialMetadata" type="mo:MinimumEssentialMetadataType" nillable="true">
     <xs:annotation>
       <xs:documentation>Metadata about a data resource necessary to support the ‘must have’ functions for any data across DoD, joint, interagency, and coalition at the time of ‘creation’ that will be exchanged.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="MinimumEssentialMetadataAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for mo:MinimumEssentialMetadataType.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="MissionAugmentation" type="mo:MissionAugmentationType" substitutionGroup="nc:MissionAugmentationPoint" nillable="true">
@@ -12534,6 +12599,11 @@
       <xs:documentation>An element for releasability information.</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="ReportAugmentation" type="mo:ReportAugmentationType" substitutionGroup="nc:ReportAugmentationPoint" nillable="true">
+    <xs:annotation>
+      <xs:documentation>Additional information about a report.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="RequiredLevelOfAccessCode" type="mo:AccessLevelCodeType" nillable="true">
     <xs:annotation>
       <xs:documentation>A level of target access required by the weapon.</xs:documentation>
@@ -13212,6 +13282,11 @@
   <xs:element name="UncertaintyMetadata" type="mo:UncertaintyMetadataType" nillable="true">
     <xs:annotation>
       <xs:documentation>Information that further qualifies the uncertainty in primary data; uncertainty data about data.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="UncertaintyMetadataAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for mo:UncertaintyMetadataType.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="UncertaintyQualityMethodCode" type="mo:UncertaintyQualityMethodCodeType" nillable="true">

--- a/xsd/domains/screening.xsd
+++ b/xsd/domains/screening.xsd
@@ -19871,6 +19871,18 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  <xs:complexType name="PersonAugmentationType">
+    <xs:annotation>
+      <xs:documentation>A data type for additional information about a person.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="structures:AugmentationType">
+        <xs:sequence>
+          <xs:element ref="scr:PersonMetadata" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
   <xs:complexType name="PersonBiometricAssociationType">
     <xs:annotation>
       <xs:documentation>A data type for an association that distinguishes physical characteristics captured at the time of person encounter.</xs:documentation>
@@ -20612,10 +20624,11 @@
       <xs:documentation>A data type for metadata about the data associated with a person being screened.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="structures:MetadataType">
+      <xs:extension base="nc:MetadataType">
         <xs:sequence>
           <xs:element ref="scr:ConfidenceLevel" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:PersonConfidenceLevelPercent" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="scr:PersonMetadataAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -23556,6 +23569,11 @@
       <xs:documentation>A date that a Person arrived in the U.S.</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="PersonAugmentation" type="scr:PersonAugmentationType" substitutionGroup="nc:PersonAugmentationPoint" nillable="true">
+    <xs:annotation>
+      <xs:documentation>Additional information about a person.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="PersonBiometricAssociation" type="scr:PersonBiometricAssociationType" nillable="true">
     <xs:annotation>
       <xs:documentation>An association between a person and distinguishing physical characteristic captured at the time of PERSON ENCOUNTER.</xs:documentation>
@@ -23794,6 +23812,11 @@
   <xs:element name="PersonMetadata" type="scr:PersonMetadataType" nillable="true" appinfo:appliesToTypes="nc:PersonType">
     <xs:annotation>
       <xs:documentation>Information that further qualifies Screening purposes.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="PersonMetadataAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for scr:PersonMetadataType.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="PersonNameAugmentation" type="scr:PersonNameAugmentationType" substitutionGroup="nc:PersonNameAugmentationPoint" nillable="true">

--- a/xsd/niem-core.xsd
+++ b/xsd/niem-core.xsd
@@ -2938,6 +2938,7 @@
           <xs:element ref="nc:SourceContactPersonAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:SourceIDText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:SourceText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:MetadataAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -10143,6 +10144,11 @@
   <xs:element name="Metadata" type="nc:MetadataType" nillable="true" appinfo:appliesToTypes="structures:AssociationType structures:ObjectType">
     <xs:annotation>
       <xs:documentation>Information that further qualifies primary data; data about data.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="MetadataAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for nc:MetadataType.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="MilitaryBranchName" type="nc:TextType" nillable="true">


### PR DESCRIPTION

**NDR changes now treat metadata components like regular components:**

- Metadata types can use type extension
- Metadata types must support augmentation
- Metadata properties may be contained in other types

**Leveraged type extension for the following types:**

- `scr:PersonMetadataType` now extends `nc:MetadataType`

**Created augmentation points for the following metadata types:**

- `nc:MetadataType`
- `cbrn:TotalDoseMetadataType`
- `cbrn:TotalExposureMetadataType`
- `cui:DocumentMarkingMetadataType`
- `cui:PortionMarkingMetadataType`
- `mo:ImplementationSpecificSettingMetadataType`
- `mo:MinimumEssentialMetadataType`
- `mo:UncertaintyMetadataType`
- `scr:PersonMetadataType`

**Converted the following metadata types to augmentations of `nc:MetadataType`:**

- `hs:MetadataType`
- `j:MetadataType`

**Added the following metadata properties to types:**

- `cbrn:totalDoseMetadataRef`
  - Added to type `cbrn:TotalDoseuSvType` as a metadata attribute augmentation
- `cbrn:totalExposureMetadataRef`
  - Added to type `cbrn:TotalExposuremRType` as a metadata attribute augmentation
- `cui:DocumentMarkingMetadata`
  - Added to type `cui:DocumentAugmentationType`
  - Added to type `cui:ReportAugmentationType`
  - Added to type `cui:MessageAugmentationType`
- `mo:ImplementationSpecificSettingMetadata`
  - Added to type `mo:SettingType`
- `mo:MinimumEssentialMetadata`
  - Added to type `mo:DocumentAugmentationType`
  - Added to type `mo:ReportAugmentationType`
  - Added to type `mo:MessageAugmentationType`
- `mo:UncertaintyMetadata`
  - Added to type `mo:MeasureAugmentationType`
- `scr:PersonMetadata`
  - Added to type `scr:PersonAugmentationType`
