### PR TITLE
Renamed Maritime's USMTFEnvironmentCategoryCode components (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,11 @@ NIEM is now an OASIS Open Project.  URIs for each namespace have been updated to
 <!-- URI for NIEM Core for 6.0 -->
 <xs:schema targetNamespace="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/" ...>
 ```
+
+#### Renamed Maritime domain's USMTFEnvironmentCategoryCode components ([niemopen/niem-model#23](https://github.com/niemopen/niem-model/issues/23))
+
+The names and definitions of the following components in the Maritime domain have been updated to remove the term "USMTF", as these are no longer defined by that standard:
+
+- `m:USMTFEnvironmentCategoryCode`
+- `m:USMTFEnvironmentCategoryCodeType`
+- `m:USMTFEnvironmentCategoryCodeSimpleType`

--- a/xsd/domains/maritime.xsd
+++ b/xsd/domains/maritime.xsd
@@ -1080,6 +1080,53 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  <xs:simpleType name="EnvironmentCategoryCodeSimpleType">
+    <xs:annotation>
+      <xs:documentation>A data type for a force-threat designator code used in combination with threat codes.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="AIR">
+        <xs:annotation>
+          <xs:documentation>Air</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="LND">
+        <xs:annotation>
+          <xs:documentation>Land</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="SPC">
+        <xs:annotation>
+          <xs:documentation>Space</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="SUB">
+        <xs:annotation>
+          <xs:documentation>Subsurface</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="SUR">
+        <xs:annotation>
+          <xs:documentation>Surface</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="UNK">
+        <xs:annotation>
+          <xs:documentation>Unknown</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="EnvironmentCategoryCodeType">
+    <xs:annotation>
+      <xs:documentation>A data type for a force-threat designator code used in combination with threat codes.</xs:documentation>
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="m:EnvironmentCategoryCodeSimpleType">
+        <xs:attributeGroup ref="structures:SimpleObjectAttributeGroup"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
   <xs:complexType name="HazmatDeclarationType">
     <xs:annotation>
       <xs:documentation>A data type for a declaration of hazardous materials within transported goods.</xs:documentation>
@@ -1468,53 +1515,6 @@
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
-  </xs:complexType>
-  <xs:simpleType name="USMTFEnvironmentCategoryCodeSimpleType">
-    <xs:annotation>
-      <xs:documentation>A data type for a USMTF-defined force-threat designator code used in combination with threat codes.</xs:documentation>
-    </xs:annotation>
-    <xs:restriction base="xs:token">
-      <xs:enumeration value="AIR">
-        <xs:annotation>
-          <xs:documentation>Air</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
-      <xs:enumeration value="LND">
-        <xs:annotation>
-          <xs:documentation>Land</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
-      <xs:enumeration value="SPC">
-        <xs:annotation>
-          <xs:documentation>Space</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
-      <xs:enumeration value="SUB">
-        <xs:annotation>
-          <xs:documentation>Subsurface</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
-      <xs:enumeration value="SUR">
-        <xs:annotation>
-          <xs:documentation>Surface</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
-      <xs:enumeration value="UNK">
-        <xs:annotation>
-          <xs:documentation>Unknown</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:complexType name="USMTFEnvironmentCategoryCodeType">
-    <xs:annotation>
-      <xs:documentation>A data type for a USMTF-defined force-threat designator code used in combination with threat codes.</xs:documentation>
-    </xs:annotation>
-    <xs:simpleContent>
-      <xs:extension base="m:USMTFEnvironmentCategoryCodeSimpleType">
-        <xs:attributeGroup ref="structures:SimpleObjectAttributeGroup"/>
-      </xs:extension>
-    </xs:simpleContent>
   </xs:complexType>
   <xs:simpleType name="USMTFThreatCodeSimpleType">
     <xs:annotation>
@@ -2017,6 +2017,11 @@
   <xs:element name="Departure" type="m:PortVisitType" nillable="true">
     <xs:annotation>
       <xs:documentation>A departure of a vessel from a port.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="EnvironmentCategoryCode" type="m:EnvironmentCategoryCodeType" substitutionGroup="m:InterestCategoryAbstract" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A kind of environment code.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="HazmatDeclaration" type="m:HazmatDeclarationType" nillable="true">
@@ -2752,11 +2757,6 @@
   <xs:element name="ShipmentStatus" type="nc:StatusType" nillable="true">
     <xs:annotation>
       <xs:documentation>A status of a shipment.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="USMTFEnvironmentCategoryCode" type="m:USMTFEnvironmentCategoryCodeType" substitutionGroup="m:InterestCategoryAbstract" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A kind of USMTF-defined environment code.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="USMTFThreatCode" type="m:USMTFThreatCodeType" substitutionGroup="m:InterestLevelAbstract" nillable="true">


### PR DESCRIPTION
The names and definitions of the following components in the Maritime domain have been updated to remove the term "USMTF", as these are no longer defined by that standard:

- `m:USMTFEnvironmentCategoryCode`
- `m:USMTFEnvironmentCategoryCodeType`
- `m:USMTFEnvironmentCategoryCodeSimpleType`
