### PR TITLE
Updates and qa fixes

### DIFF
--- a/xsd/auxiliary/cui.xsd
+++ b/xsd/auxiliary/cui.xsd
@@ -1059,7 +1059,7 @@
   </xs:complexType>
   <xs:attribute name="portionMarkingMetadataRef" type="xs:IDREFS">
     <xs:annotation>
-      <xs:documentation>An attribute reference to cui:PortionMarkingMetadata.</xs:documentation>
+      <xs:documentation>A list of metadata objects about Controlled Unclassified Information (CUI) portion marking that apply to a node or object represented by an XML element.</xs:documentation>
     </xs:annotation>
   </xs:attribute>
   <xs:element name="BasicCategoryMarkingCode" type="cui:BasicCategoryMarkingCodeType" nillable="true">

--- a/xsd/domains/cbrn.xsd
+++ b/xsd/domains/cbrn.xsd
@@ -4879,7 +4879,7 @@
       <xs:documentation>A value for the total counts observed.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="TotalDoseMetadata" type="cbrn:TotalDoseMetadataType" nillable="true" appinfo:appliesToTypes="structures:ObjectType">
+  <xs:element name="TotalDoseMetadata" type="cbrn:TotalDoseMetadataType" nillable="true">
     <xs:annotation>
       <xs:documentation>Metadata about the accumulated ambient dose equivalent since the last radiation detection instrument reset, with units microsieverts (Sv).</xs:documentation>
     </xs:annotation>
@@ -4904,7 +4904,7 @@
       <xs:documentation>A total efficiency calibration. The total efficiency at any value of energy is the ratio of the total recorded pulses in a spectrum to the number of photons emitted from a source at that energy.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="TotalExposureMetadata" type="cbrn:TotalExposureMetadataType" nillable="true" appinfo:appliesToTypes="structures:ObjectType">
+  <xs:element name="TotalExposureMetadata" type="cbrn:TotalExposureMetadataType" nillable="true">
     <xs:annotation>
       <xs:documentation>Metadata about accumulated exposure since the last instrument reset, in milliroentgen (mR).</xs:documentation>
     </xs:annotation>

--- a/xsd/domains/cbrn.xsd
+++ b/xsd/domains/cbrn.xsd
@@ -2131,12 +2131,12 @@
   </xs:attribute>
   <xs:attribute name="totalDoseMetadataRef" type="xs:IDREFS">
     <xs:annotation>
-      <xs:documentation>An attribute reference to cbrn:totalDoseMetadataRef.</xs:documentation>
+      <xs:documentation>A list of metadata objects about the accumulated ambient dose equivalent since the last radiation detection instrument reset, with units microsieverts (Sv), that apply to a node or object represented by an XML element.</xs:documentation>
     </xs:annotation>
   </xs:attribute>
   <xs:attribute name="totalExposureMetadataRef" type="xs:IDREFS">
     <xs:annotation>
-      <xs:documentation>An attribute reference to cbrn:totalExposureMetadataRef.</xs:documentation>
+      <xs:documentation>A list of metadata objects about accumulated exposure since the last instrument reset, in milliroentgen (mR), that apply to a node or object represented by an XML element.</xs:documentation>
     </xs:annotation>
   </xs:attribute>
   <xs:attribute name="unitsText" type="xs:token">

--- a/xsd/domains/hs.xsd
+++ b/xsd/domains/hs.xsd
@@ -6187,30 +6187,6 @@
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
-  <xs:complexType name="StudentType">
-    <xs:annotation>
-      <xs:documentation>A data type for a student.</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="nc:PersonType">
-        <xs:sequence>
-          <xs:element ref="hs:StudentCurrentEducationGradeLevelAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="hs:StudentCurrentEducationDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="hs:StudentCurrentEducationEnrollmentIndicator" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="hs:StudentCurrentEducationEnrollmentEndDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="hs:StudentCurrentEducationTruancyIndicator" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="hs:EducationalIssues" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="hs:EducationalAdjustmentAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="hs:StudentSpecialEducationEligibleIndicator" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="hs:StudentSpecialEducationDetails" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="hs:StudentSchoolConductChangeText" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="hs:StudentIdentification" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="hs:StudentPhotoImage" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="hs:StudentAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
   <xs:complexType name="SubjectChildAssociationType">
     <xs:annotation>
       <xs:documentation>A data type for an association between a subject and a child.</xs:documentation>

--- a/xsd/domains/mo.xsd
+++ b/xsd/domains/mo.xsd
@@ -4437,6 +4437,18 @@
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
+  <xs:complexType name="DocumentAugmentationType">
+    <xs:annotation>
+      <xs:documentation>A data type for additional information about a document.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="structures:AugmentationType">
+        <xs:sequence>
+          <xs:element ref="mo:MinimumEssentialMetadata" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
   <xs:complexType name="EllipseType">
     <xs:annotation>
       <xs:documentation>A data type for an ellipse, expressed as an XY plane (projected onto earth's surface) ellipse. The major axis is oriented along reported azimuth, with zero being due North.</xs:documentation>

--- a/xsd/domains/mo.xsd
+++ b/xsd/domains/mo.xsd
@@ -10250,7 +10250,7 @@
       <xs:documentation>A vertical elevation of an object above a surface (as sea level or land) of a planet or natural satellite.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="AnalyticNoteMetadata" type="nc:MetadataType" nillable="true" appinfo:appliesToTypes="structures:AssociationType structures:ObjectType">
+  <xs:element name="AnalyticNoteMetadata" type="nc:MetadataType" nillable="true">
     <xs:annotation>
       <xs:documentation>Metadata about analyst notes throughout the model, this tracks any notes or comments made regarding data.</xs:documentation>
     </xs:annotation>
@@ -10535,7 +10535,7 @@
       <xs:documentation>A digital signature computed upon this X.509 certificate.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="CETMetadata" type="nc:MetadataType" nillable="true" appinfo:appliesToTypes="structures:AssociationType structures:ObjectType">
+  <xs:element name="CETMetadata" type="nc:MetadataType" nillable="true">
     <xs:annotation>
       <xs:documentation>Information that further qualifies Cyber Effectiveness Table (CET) data; data about data.</xs:documentation>
     </xs:annotation>
@@ -12550,7 +12550,7 @@
       <xs:documentation>A description the programming language used.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="ProvenanceMetadata" type="nc:MetadataType" nillable="true" appinfo:appliesToTypes="structures:AssociationType structures:ObjectType">
+  <xs:element name="ProvenanceMetadata" type="nc:MetadataType" nillable="true">
     <xs:annotation>
       <xs:documentation>Metadata about nodes and links in a network.</xs:documentation>
     </xs:annotation>
@@ -13370,7 +13370,7 @@
       <xs:documentation>An identifier for a seven-character alphanumeric code that describes a unique increment of a unit deployment, i.e., advance party, main body, equipment by sea and air, reception team, or trail party, in the time-phased force and deployment data. Also called ULN. (JP 3-35)</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="UnitMetadata" type="nc:MetadataType" nillable="true" appinfo:appliesToTypes="structures:AssociationType structures:ObjectType">
+  <xs:element name="UnitMetadata" type="nc:MetadataType" nillable="true">
     <xs:annotation>
       <xs:documentation>Information that further qualifies primary data about a unit; data about unit data.</xs:documentation>
     </xs:annotation>
@@ -13550,7 +13550,7 @@
       <xs:documentation>A point to which a moving object may be vectored.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="WCMMetadata" type="nc:MetadataType" nillable="true" appinfo:appliesToTypes="structures:AssociationType structures:ObjectType">
+  <xs:element name="WCMMetadata" type="nc:MetadataType" nillable="true">
     <xs:annotation>
       <xs:documentation>Information that further qualifies Weapon Characterization Model (WCM) data; data about data.</xs:documentation>
     </xs:annotation>

--- a/xsd/domains/screening.xsd
+++ b/xsd/domains/screening.xsd
@@ -23778,7 +23778,7 @@
       <xs:documentation>A data concept for a status of the medical condition of a person.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="PersonMetadata" type="scr:PersonMetadataType" nillable="true" appinfo:appliesToTypes="nc:PersonType">
+  <xs:element name="PersonMetadata" type="scr:PersonMetadataType" nillable="true">
     <xs:annotation>
       <xs:documentation>Information that further qualifies Screening purposes.</xs:documentation>
     </xs:annotation>

--- a/xsd/niem-core.xsd
+++ b/xsd/niem-core.xsd
@@ -5030,7 +5030,7 @@
   </xs:attribute>
   <xs:attribute name="metadataRef" type="xs:IDREFS">
     <xs:annotation>
-      <xs:documentation>An attribute reference to nc:Metadata.</xs:documentation>
+      <xs:documentation>A list of metadata objects that apply to a node or object represented by an XML element.</xs:documentation>
     </xs:annotation>
   </xs:attribute>
   <xs:attribute name="partialIndicator" type="xs:boolean">

--- a/xsd/niem-core.xsd
+++ b/xsd/niem-core.xsd
@@ -10233,7 +10233,7 @@
       <xs:documentation>A body or main content of a message.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="Metadata" type="nc:MetadataType" nillable="true" appinfo:appliesToTypes="structures:AssociationType structures:ObjectType">
+  <xs:element name="Metadata" type="nc:MetadataType" nillable="true">
     <xs:annotation>
       <xs:documentation>Information that further qualifies primary data; data about data.</xs:documentation>
     </xs:annotation>


### PR DESCRIPTION
The following updates have been made:

- Added mo:DocumentAugmentationType as part of metadata changes (niemopen/niem-naming-design-rules#8)
- Removed appinfo appliesTo attributes from metadata properties (niemopen/niem-naming-design-rules#8)
- Removed hs:StudentType as part of student harmonization (#52)
  - StudentType now appears in Core
  - Human Services now has an augmentation 
- Updated attribute augmentation property definitions (#46)
