### PR TITLE
Synchronize Justice domain version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,9 +605,29 @@ Updated the following properties to no longer be abstract and to have type `nc:C
 - j:DriverLicenseIssuingCountryAbstract
 - mo:ObservedObjectAllegianceCountryAbstract
 
+### Synchronized Justice domain version number
+
+The NIEM Justice domain originated from the GLOBAL Justice XML Data Model (GJXDM), the predecessor to NIEM.  Since the beginning of NIEM, the Justice domain has continued to use GJXDM version numbers for its own version (2 major version numbers ahead) rather than NIEM version numbers.
+
+For consistency and easier tool support going forward, the Justice domain version numbers have now been synchronized with the rest of the model.
+
+The new pattern for NIEM URIs under OASIS prevent collisions with older versions.  The domain identifier is also being changed from `jxdm` to `justice` to make clear that the new version number applies to the NIEM Justice domain, not the GJXDM.
+
+**NIEM 5.2:**
+
+- URI: http://release.niem.gov/niem/domains/jxdm/7.2/
+- Definition: "Justice"
+- Filename" "jxdm.xsd"
+
+**NIEM 6.0:**
+
+- URI: https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/
+- Definition: "Justice domain 6.0 / GJXDM 8.0"
+- Filename" "jxdm.xsd"
+
 ### Adapter updates
 
-### Standardized the convention for adapter namespaces ([niemopen/niem-model#35](https://github.com/niemopen/niem-model/issues/35))
+#### Standardized the convention for adapter namespaces ([niemopen/niem-model#35](https://github.com/niemopen/niem-model/issues/35))
 
 Updated adapter namespace prefixes, uris, and filenames to follow the convention used by the `niem-xs` namespace, which creates special kinds of proxy adapters for XML Schema simple types.
 

--- a/json-ld/context.json
+++ b/json-ld/context.json
@@ -32,7 +32,7 @@
   "iso_639-5": "https://docs.oasis-open.org/niemopen/ns/model/codes/iso_639-5/6.0/#",
   "it": "https://docs.oasis-open.org/niemopen/ns/model/domains/internationalTrade/6.0/#",
   "itcodes": "https://docs.oasis-open.org/niemopen/ns/model/codes/it_codes/6.0/#",
-  "j": "https://docs.oasis-open.org/niemopen/ns/model/domains/jxdm/8.0/#",
+  "j": "https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/#",
   "jc3iedm": "https://docs.oasis-open.org/niemopen/ns/model/codes/jc3iedm/6.0/#",
   "jp2-0": "https://docs.oasis-open.org/niemopen/ns/model/codes/jp2-0/6.0/#",
   "jp3-52": "https://docs.oasis-open.org/niemopen/ns/model/codes/jp3-52/6.0/#",

--- a/xsd/domains/emergencyManagement.xsd
+++ b/xsd/domains/emergencyManagement.xsd
@@ -16,7 +16,7 @@
   xmlns:have-codes="https://docs.oasis-open.org/niemopen/ns/model/codes/edxl_have/6.0/"
   xmlns:iso_639-3="https://docs.oasis-open.org/niemopen/ns/model/codes/iso_639-3/6.0/"
   xmlns:it="https://docs.oasis-open.org/niemopen/ns/model/domains/internationalTrade/6.0/"
-  xmlns:j="https://docs.oasis-open.org/niemopen/ns/model/domains/jxdm/8.0/"
+  xmlns:j="https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/"
   xmlns:mo="https://docs.oasis-open.org/niemopen/ns/model/domains/militaryOperations/6.0/"
   xmlns:nc="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/"
   xmlns:niem-cap="https://docs.oasis-open.org/niemopen/ns/model/adapters/niem-cap/6.0/"
@@ -80,7 +80,7 @@
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/codes/iso_639-3/6.0/" schemaLocation="../codes/iso_639-3.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/biometrics/6.0/" schemaLocation="biom.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/internationalTrade/6.0/" schemaLocation="internationalTrade.xsd"/>
-  <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/jxdm/8.0/" schemaLocation="jxdm.xsd"/>
+  <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/" schemaLocation="justice.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/militaryOperations/6.0/" schemaLocation="mo.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/screening/6.0/" schemaLocation="screening.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/" schemaLocation="../niem-core.xsd"/>

--- a/xsd/domains/hs.xsd
+++ b/xsd/domains/hs.xsd
@@ -10,7 +10,7 @@
   xmlns:fips="https://docs.oasis-open.org/niemopen/ns/model/codes/fips/6.0/"
   xmlns:hs="https://docs.oasis-open.org/niemopen/ns/model/domains/humanServices/6.0/"
   xmlns:im="https://docs.oasis-open.org/niemopen/ns/model/domains/immigration/6.0/"
-  xmlns:j="https://docs.oasis-open.org/niemopen/ns/model/domains/jxdm/8.0/"
+  xmlns:j="https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/"
   xmlns:nc="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/"
   xmlns:niem-xs="https://docs.oasis-open.org/niemopen/ns/model/adapters/niem-xs/6.0/"
   xmlns:scr="https://docs.oasis-open.org/niemopen/ns/model/domains/screening/6.0/"
@@ -51,7 +51,7 @@
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/adapters/niem-xs/6.0/" schemaLocation="../adapters/niem-xs.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/codes/fips/6.0/" schemaLocation="../codes/fips.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/immigration/6.0/" schemaLocation="immigration.xsd"/>
-  <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/jxdm/8.0/" schemaLocation="jxdm.xsd"/>
+  <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/" schemaLocation="justice.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/screening/6.0/" schemaLocation="screening.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/" schemaLocation="../niem-core.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/" schemaLocation="../utility/structures.xsd"/>

--- a/xsd/domains/immigration.xsd
+++ b/xsd/domains/immigration.xsd
@@ -9,7 +9,7 @@
   xmlns:ct="https://docs.oasis-open.org/niemopen/ns/specification/conformanceTargets/6.0/"
   xmlns:hs="https://docs.oasis-open.org/niemopen/ns/model/domains/humanServices/6.0/"
   xmlns:im="https://docs.oasis-open.org/niemopen/ns/model/domains/immigration/6.0/"
-  xmlns:j="https://docs.oasis-open.org/niemopen/ns/model/domains/jxdm/8.0/"
+  xmlns:j="https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/"
   xmlns:nc="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/"
   xmlns:niem-xs="https://docs.oasis-open.org/niemopen/ns/model/adapters/niem-xs/6.0/"
   xmlns:scr="https://docs.oasis-open.org/niemopen/ns/model/domains/screening/6.0/"
@@ -40,7 +40,7 @@
   </xs:annotation>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/adapters/niem-xs/6.0/" schemaLocation="../adapters/niem-xs.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/humanServices/6.0/" schemaLocation="hs.xsd"/>
-  <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/jxdm/8.0/" schemaLocation="jxdm.xsd"/>
+  <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/" schemaLocation="justice.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/screening/6.0/" schemaLocation="screening.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/" schemaLocation="../niem-core.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/" schemaLocation="../utility/structures.xsd"/>

--- a/xsd/domains/intelligence.xsd
+++ b/xsd/domains/intelligence.xsd
@@ -9,7 +9,7 @@
   xmlns:biom="https://docs.oasis-open.org/niemopen/ns/model/domains/biometrics/6.0/"
   xmlns:ct="https://docs.oasis-open.org/niemopen/ns/specification/conformanceTargets/6.0/"
   xmlns:intel="https://docs.oasis-open.org/niemopen/ns/model/domains/intelligence/6.0/"
-  xmlns:j="https://docs.oasis-open.org/niemopen/ns/model/domains/jxdm/8.0/"
+  xmlns:j="https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/"
   xmlns:nc="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/"
   xmlns:ncic="https://docs.oasis-open.org/niemopen/ns/model/codes/ncic/6.0/"
   xmlns:niem-xs="https://docs.oasis-open.org/niemopen/ns/model/adapters/niem-xs/6.0/"
@@ -37,7 +37,7 @@
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/adapters/niem-xs/6.0/" schemaLocation="../adapters/niem-xs.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/codes/ncic/6.0/" schemaLocation="../codes/ncic.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/biometrics/6.0/" schemaLocation="biom.xsd"/>
-  <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/jxdm/8.0/" schemaLocation="jxdm.xsd"/>
+  <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/" schemaLocation="justice.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/" schemaLocation="../niem-core.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/" schemaLocation="../utility/structures.xsd"/>
   <xs:complexType name="AgencyInterestCategoryType">

--- a/xsd/domains/internationalTrade.xsd
+++ b/xsd/domains/internationalTrade.xsd
@@ -12,7 +12,7 @@
   xmlns:iso_4217="https://docs.oasis-open.org/niemopen/ns/model/codes/iso_4217/6.0/"
   xmlns:it="https://docs.oasis-open.org/niemopen/ns/model/domains/internationalTrade/6.0/"
   xmlns:itcodes="https://docs.oasis-open.org/niemopen/ns/model/codes/it_codes/6.0/"
-  xmlns:j="https://docs.oasis-open.org/niemopen/ns/model/domains/jxdm/8.0/"
+  xmlns:j="https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/"
   xmlns:nc="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/"
   xmlns:niem-xs="https://docs.oasis-open.org/niemopen/ns/model/adapters/niem-xs/6.0/"
   xmlns:scr="https://docs.oasis-open.org/niemopen/ns/model/domains/screening/6.0/"
@@ -48,7 +48,7 @@
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/codes/iso_4217/6.0/" schemaLocation="../codes/iso_4217.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/codes/it_codes/6.0/" schemaLocation="../codes/it_codes.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/cbrn/6.0/" schemaLocation="cbrn.xsd"/>
-  <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/jxdm/8.0/" schemaLocation="jxdm.xsd"/>
+  <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/" schemaLocation="justice.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/screening/6.0/" schemaLocation="screening.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/" schemaLocation="../niem-core.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/" schemaLocation="../utility/structures.xsd"/>

--- a/xsd/domains/justice.xsd
+++ b/xsd/domains/justice.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema
-  targetNamespace="https://docs.oasis-open.org/niemopen/ns/model/domains/jxdm/8.0/"
+  targetNamespace="https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/"
   version="psd01"
   xml:lang="en-US"
   xsi:schemaLocation="https://docs.oasis-open.org/niemopen/ns/model/appinfo/6.0/ ../utility/appinfo.xsd https://docs.oasis-open.org/niemopen/ns/specification/conformanceTargets/6.0/ ../utility/conformanceTargets.xsd"
@@ -15,7 +15,7 @@
   xmlns:em="https://docs.oasis-open.org/niemopen/ns/model/domains/emergencyManagement/6.0/"
   xmlns:hs="https://docs.oasis-open.org/niemopen/ns/model/domains/humanServices/6.0/"
   xmlns:im="https://docs.oasis-open.org/niemopen/ns/model/domains/immigration/6.0/"
-  xmlns:j="https://docs.oasis-open.org/niemopen/ns/model/domains/jxdm/8.0/"
+  xmlns:j="https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/"
   xmlns:mmucc="https://docs.oasis-open.org/niemopen/ns/model/codes/mmucc/6.0/"
   xmlns:nc="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/"
   xmlns:ndex="https://docs.oasis-open.org/niemopen/ns/model/codes/ndex/6.0/"
@@ -28,7 +28,7 @@
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <xs:annotation>
-    <xs:documentation>Justice</xs:documentation>
+    <xs:documentation>Justice domain 6.0 / GJXDM 8.0</xs:documentation>
     <xs:appinfo>
       <appinfo:LocalTerm term="AAMVA" literal="The American Association of Motor Vehicle Administrators"/>
       <appinfo:LocalTerm term="ACD" literal="AAMVA Code Dictionary"/>

--- a/xsd/domains/learn-dev.xsd
+++ b/xsd/domains/learn-dev.xsd
@@ -7,7 +7,7 @@
   ct:conformanceTargets="https://docs.oasis-open.org/niemopen/ns/specification/XNDR/6.0/#ReferenceSchemaDocument"
   xmlns:appinfo="https://docs.oasis-open.org/niemopen/ns/model/appinfo/6.0/"
   xmlns:ct="https://docs.oasis-open.org/niemopen/ns/specification/conformanceTargets/6.0/"
-  xmlns:j="https://docs.oasis-open.org/niemopen/ns/model/domains/jxdm/8.0/"
+  xmlns:j="https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/"
   xmlns:lrn-dev="https://docs.oasis-open.org/niemopen/ns/model/domains/learn-dev/6.0/"
   xmlns:nc="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/"
   xmlns:niem-xs="https://docs.oasis-open.org/niemopen/ns/model/adapters/niem-xs/6.0/"
@@ -25,7 +25,7 @@
     </xs:appinfo>
   </xs:annotation>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/adapters/niem-xs/6.0/" schemaLocation="../adapters/niem-xs.xsd"/>
-  <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/jxdm/8.0/" schemaLocation="jxdm.xsd"/>
+  <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/" schemaLocation="justice.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/" schemaLocation="../niem-core.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/" schemaLocation="../utility/structures.xsd"/>
   <xs:simpleType name="CourseInteractionModeCodeSimpleType">

--- a/xsd/domains/screening.xsd
+++ b/xsd/domains/screening.xsd
@@ -12,7 +12,7 @@
   xmlns:im="https://docs.oasis-open.org/niemopen/ns/model/domains/immigration/6.0/"
   xmlns:intel="https://docs.oasis-open.org/niemopen/ns/model/domains/intelligence/6.0/"
   xmlns:it="https://docs.oasis-open.org/niemopen/ns/model/domains/internationalTrade/6.0/"
-  xmlns:j="https://docs.oasis-open.org/niemopen/ns/model/domains/jxdm/8.0/"
+  xmlns:j="https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/"
   xmlns:m="https://docs.oasis-open.org/niemopen/ns/model/domains/maritime/6.0/"
   xmlns:nc="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/"
   xmlns:niem-xs="https://docs.oasis-open.org/niemopen/ns/model/adapters/niem-xs/6.0/"
@@ -43,7 +43,7 @@
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/immigration/6.0/" schemaLocation="immigration.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/intelligence/6.0/" schemaLocation="intelligence.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/internationalTrade/6.0/" schemaLocation="internationalTrade.xsd"/>
-  <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/jxdm/8.0/" schemaLocation="jxdm.xsd"/>
+  <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/" schemaLocation="justice.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/maritime/6.0/" schemaLocation="maritime.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/" schemaLocation="../niem-core.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/" schemaLocation="../utility/structures.xsd"/>

--- a/xsd/xml-catalog.xml
+++ b/xsd/xml-catalog.xml
@@ -57,7 +57,7 @@
   <uri name="https://docs.oasis-open.org/niemopen/ns/model/domains/infrastructureProtection/6.0/" uri="domains/infrastructureProtection.xsd"/>
   <uri name="https://docs.oasis-open.org/niemopen/ns/model/domains/intelligence/6.0/" uri="domains/intelligence.xsd"/>
   <uri name="https://docs.oasis-open.org/niemopen/ns/model/domains/internationalTrade/6.0/" uri="domains/internationalTrade.xsd"/>
-  <uri name="https://docs.oasis-open.org/niemopen/ns/model/domains/jxdm/8.0/" uri="domains/jxdm.xsd"/>
+  <uri name="https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/" uri="domains/justice.xsd"/>
   <uri name="https://docs.oasis-open.org/niemopen/ns/model/domains/learn-dev/6.0/" uri="domains/learn-dev.xsd"/>
   <uri name="https://docs.oasis-open.org/niemopen/ns/model/domains/maritime/6.0/" uri="domains/maritime.xsd"/>
   <uri name="https://docs.oasis-open.org/niemopen/ns/model/domains/militaryOperations/6.0/" uri="domains/mo.xsd"/>


### PR DESCRIPTION
### Synchronize Justice domain version number (#42)

The NIEM Justice domain originated from the GLOBAL Justice XML Data Model (GJXDM), the predecessor to NIEM.  Since the beginning of NIEM, the Justice domain has continued to use GJXDM version numbers for its own version (2 major version numbers ahead) rather than NIEM version numbers.

For consistency and easier tool support going forward, the Justice domain version numbers have now been synchronized with the rest of the model.

The new pattern for NIEM URIs under OASIS prevent collisions with older versions.  The domain identifier is also being changed from `jxdm` to `justice` to make clear that the new version number applies to the NIEM Justice domain, not the GJXDM.

**NIEM 5.2:**

- URI: http://release.niem.gov/niem/domains/jxdm/7.2/
- Definition: "Justice"
- Filename" "jxdm.xsd"

**NIEM 6.0:**

- URI: https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/
- Definition: "Justice domain 6.0 / GJXDM 8.0"
- Filename" "jxdm.xsd"
