### PR TITLE
Add support for new digital identification and license requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,52 @@ Updated the following properties to no longer be abstract and to have type `nc:C
 - j:DriverLicenseIssuingCountryAbstract
 - mo:ObservedObjectAllegianceCountryAbstract
 
+### Added support for new digital identification and license requirements ([#37](https://github.com/niemopen/niem-model/issues/37))
+
+The Department of Homeland Security (DHS) is working to establish digital identity standards. This will help the 50 states harmonize their digital identity attributes such as driver licenses, FAA licenses such as pilot licenses, TSA inner system to system communications for validation of identity documentation, coast guard marine licenses, DoT related Truck licenses and more.
+
+The Emergency Management domain has worked with several states and the FAA to harmonize an initial set of requirements.  Existing identification- and license-related components in NIEM have been reviewed and refactored as needed to support the new requirements.
+
+Key changes include:
+
+- `nc:IdentificationType`
+  - Added new properties
+  - Added refactored properties from domain augmentations
+
+- `nc:LicenseType`
+
+  - Added as a new type to support other kinds of licenses.
+  - Extends `nc:IdentificationType`
+  - Added new properties
+  - Added refactored properties from `j:DriverLicenseBaseType`
+
+- `j:DriverLicenseType` and related types
+
+  - Updated to extend the new `nc:LicenseType`
+  - Refactored the more generic properties to `nc:LicenseType` and related types
+  - Added "driver license, DL" keywords to former driver license-specific properties to support the ability for users to find these properties under new, more generic names
+
+- `nc:PassportType`
+
+  - Updated to extend `nc:IdentificationType`
+  - Removed individual person-specific properties like `nc:PersonName` and `nc:PersonBirthDate` in favor of the new `nc:IdentificationPerson` property which supports the use of any property from `nc:PersonType` or an augmentation of it
+
+- `em:PersonIDCardType`
+
+  - Refactored and moved some properties to `nc:IdentificationType`
+  - Converted to an augmentation of `nc:IdentificationType`
+
+- `m:SeamanLicenseType`
+
+  - Refactored and moved some ratings properties to the new `nc:LicenseType`
+  - Removed this type because its contents can now be represented by the new `nc:LicenseType`
+  - Changed property `m:SeamanLicense` to type `nc:LicenseType`
+
+- `m:MerchantMarinerDocumentType`
+
+  - Removed this type because its contents can now be represented by the new `nc:LicenseType`
+  - Changed property `m:MerchantMarinerDocument` to type `nc:LicenseType`
+
 ### Refactored nc:EmployeeAssignmentAssociation ([#14](https://github.com/niemopen/niem-model/issues/14))
 
 Moved `nc:nc:EmployeeRegistrationAbstract` and `nc:EmployeeSupervisorIndicator` elements to from type `nc:EmployeeAssignmentAssociationType` to its parent type `nc:EmploymentAssociationType`.  This allows those properties to be used in any employment association, not just assignments.
@@ -210,6 +256,18 @@ The new pattern for NIEM URIs under OASIS prevent collisions with older versions
 - URI: https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/
 - Definition: "Justice domain 6.0 / GJXDM 8.0"
 - Filename: "justice.xsd"
+
+#### Refactored DriverLicenseType and related types ([#37](https://github.com/niemopen/niem-model/issues/37))
+
+See [Added support for new digital identification and license requirements](#added-support-for-new-digital-identification-and-license-requirements-37) above for general information about new identification and license requirements.
+
+- Refactored `j:DriverLicenseBaseType` to a more generic `nc:LicenseType`
+  - Removed properties like `j:DriverLicenseIdentification`, `j:DriverLicenseExpirationDate`, and `j:DriverLicenseIssueDate` as the new `nc:LicenseType` extends `nc:IdentificationType`, now making these identification properties inherited
+- Refactored `j:DriverLicenseType` to extend the new `nc:LicenseType`
+- Refactored `j:DriverLicenseBaseEndorsementType` and `j:DriverLicensePermitEndorsementType` to a more generic `nc:LicenseEndorsementType` and a driver license-specific `j:DriverLicenseEndorsementType`
+- Refactored `j:DriverLicenseMedicalCertificationType` to a more generic `nc:LicenseMedicalCertificationType`
+- Refactored `j:DriverLicenseRestrictionType` and `j:DriverLicensePermitRestrictionType` into a generic `nc:LicenseRestrictionType` and Justice-specific code set substitutions
+- Refactored `j:DriverLicensePermitType` to a new `nc:LicensePermitType` and Justice-specific code set substitutions
 
 #### Updated NCIC codes
 

--- a/xsd/domains/emergencyManagement.xsd
+++ b/xsd/domains/emergencyManagement.xsd
@@ -865,7 +865,7 @@
       <xs:documentation>A data type for an ID card that identifies a person. A badge can be a low cost card, or a PIV card that follows specification NIST SP-800-73-2. Badge may work together with a pin number, visual identification and biometrics of the badge holder to make a positive identification of a person</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="em:PersonIDCardType">
+      <xs:extension base="nc:IdentificationType">
         <xs:sequence>
           <xs:element ref="em:PersonHumanResource" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="em:BadgeJobTitleText" minOccurs="0" maxOccurs="unbounded"/>
@@ -4252,6 +4252,22 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  <xs:complexType name="IdentificationAugmentationType">
+    <xs:annotation>
+      <xs:documentation>A data type for additional information about an identification.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="structures:AugmentationType">
+        <xs:sequence>
+          <xs:element ref="em:ResourcePicture" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="em:NISTSP800733PIVCardData" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="em:EAssuranceLevelCode" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="em:PIVAssuranceLevelCode" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="em:FIPS201ConformanceCode" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
   <xs:simpleType name="InaccessibleCauseCodeSimpleType">
     <xs:annotation>
       <xs:documentation>A data type code to specify if the damaged area/item is assessed as inaccessible, why?</xs:documentation>
@@ -5988,28 +6004,6 @@
           <xs:element ref="em:UpdateRecord" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:Attachment" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="em:PersonHumanResourceAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-  <xs:complexType name="PersonIDCardType">
-    <xs:annotation>
-      <xs:documentation>A data type for a credential class that represents the identification of a human resource</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="nc:IdentificationType">
-        <xs:sequence>
-          <xs:element ref="em:NameOnCardText" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="em:IDCategoryCodeAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="em:SignatureAuthorityName" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="em:AgencySymbol" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="em:ResourcePicture" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="em:CardPicture" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="em:NISTSP800733PIVCardData" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="em:EAssuranceLevelCode" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="em:PIVAssuranceLevelCode" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="em:FIPS201ConformanceCode" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="em:PersonIDCardAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -10634,11 +10628,6 @@
       <xs:documentation>An augmentation point for type em:AfterActionReviewReportType</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="AgencySymbol" type="nc:BinaryType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A binary (i.e. digitized) presentation of an Agency's Symbol (i.e. Logo of the agency that the ID has been issued for)</xs:documentation>
-    </xs:annotation>
-  </xs:element>
   <xs:element name="AlarmAudibleDescriptionCode" type="em:AlarmAudibleDescriptionCodeType" nillable="true">
     <xs:annotation>
       <xs:documentation>A code indicating whether the alarm is audible or silent</xs:documentation>
@@ -11467,11 +11456,6 @@
   <xs:element name="CardioThoracicServiceCoverageStatusCode" type="have-codes:AvailabilityStatusCodeType" nillable="true">
     <xs:annotation>
       <xs:documentation>A status describing the availability of cardio-thoracic surgical services</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="CardPicture" type="nc:ImageType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A binary (i.e. digitized) presentation of an identification card picture</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Cat-CCategoryCode" type="em:Cat-CCategoryCodeType" nillable="true">
@@ -12814,11 +12798,6 @@
       <xs:documentation>An augmentation point for type em:HumanResourcesType</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="IDCategoryCodeAbstract" abstract="true">
-    <xs:annotation>
-      <xs:documentation>A data concept for a code list for identification information types for a resource e.g.  ID card number etc.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
   <xs:element name="ImmediateNeedsTernaryIndicatorCode" type="nc:YesNoUnknownCodeType" nillable="true">
     <xs:annotation>
       <xs:documentation>An indication if there are immediate needs (Yes, No, Unknown)</xs:documentation>
@@ -13549,11 +13528,6 @@
       <xs:documentation>An augmentation point for MissionInformationType</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="NameOnCardText" type="nc:TextType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A data element that is the name of the person which is printed on an identification card</xs:documentation>
-    </xs:annotation>
-  </xs:element>
   <xs:element name="NavigationInstructionsText" type="nc:TextType" nillable="true">
     <xs:annotation>
       <xs:documentation>A set of instructions that define how to get to the report to location</xs:documentation>
@@ -14094,19 +14068,9 @@
       <xs:documentation>An augmentation point for PersonHumanResourceType</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="PersonIDCard" type="em:PersonIDCardType" nillable="true">
+  <xs:element name="PersonIDCard" type="nc:IdentificationType" nillable="true">
     <xs:annotation>
       <xs:documentation>An element contains information about a person identification information</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="PersonIDCardAugmentationPoint" abstract="true">
-    <xs:annotation>
-      <xs:documentation>An augmentation point for PersonIDCardType</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="PersonIDCategoryText" type="nc:TextType" substitutionGroup="em:IDCategoryCodeAbstract" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A kind of identification type of a person</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="PersonPublication" type="nc:PublicationType" nillable="true">
@@ -14822,11 +14786,6 @@
   <xs:element name="Shelter" type="nc:FacilityType" nillable="true">
     <xs:annotation>
       <xs:documentation>A place giving temporary protection from an emergency incident or danger.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="SignatureAuthorityName" type="nc:TextType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A data element for the signature authority name on a badge</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="SituationalReport" type="em:SituationalReportType" nillable="true">

--- a/xsd/domains/intelligence.xsd
+++ b/xsd/domains/intelligence.xsd
@@ -134,9 +134,6 @@
       <xs:extension base="structures:AugmentationType">
         <xs:sequence>
           <xs:element ref="intel:AuthenticIndicator" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="intel:IdentificationIssuingCountry" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="intel:IdentificationIssuingStateName" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="intel:IdentificationIssuingLocalityText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="intel:PersonInIdentification" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -347,21 +344,6 @@
   <xs:element name="IdentificationAugmentation" type="intel:IdentificationAugmentationType" substitutionGroup="nc:IdentificationAugmentationPoint" nillable="true">
     <xs:annotation>
       <xs:documentation>Additional information about an identification.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="IdentificationIssuingCountry" type="nc:CountryType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A GeoPolitical Entity from which this identification was issued.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="IdentificationIssuingLocalityText" type="nc:TextType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A Geographic Location from which this identification was issued.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="IdentificationIssuingStateName" type="nc:TextType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A name of a major administrative district or division of a country from which this identification was issued.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="LocationAugmentation" type="intel:LocationAugmentationType" substitutionGroup="nc:LocationAugmentationPoint" nillable="true">

--- a/xsd/domains/internationalTrade.xsd
+++ b/xsd/domains/internationalTrade.xsd
@@ -12,7 +12,6 @@
   xmlns:iso_4217="https://docs.oasis-open.org/niemopen/ns/model/codes/iso_4217/6.0/"
   xmlns:it="https://docs.oasis-open.org/niemopen/ns/model/domains/internationalTrade/6.0/"
   xmlns:itcodes="https://docs.oasis-open.org/niemopen/ns/model/codes/it_codes/6.0/"
-  xmlns:j="https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/"
   xmlns:nc="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/"
   xmlns:niem-xs="https://docs.oasis-open.org/niemopen/ns/model/adapters/niem-xs/6.0/"
   xmlns:scr="https://docs.oasis-open.org/niemopen/ns/model/domains/screening/6.0/"
@@ -48,7 +47,6 @@
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/codes/iso_4217/6.0/" schemaLocation="../codes/iso_4217.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/codes/it_codes/6.0/" schemaLocation="../codes/it_codes.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/cbrn/6.0/" schemaLocation="cbrn.xsd"/>
-  <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/justice/6.0/" schemaLocation="justice.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/domains/screening/6.0/" schemaLocation="screening.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/niem-core/6.0/" schemaLocation="../niem-core.xsd"/>
   <xs:import namespace="https://docs.oasis-open.org/niemopen/ns/model/structures/6.0/" schemaLocation="../utility/structures.xsd"/>
@@ -1392,7 +1390,7 @@
         <xs:sequence>
           <xs:element ref="it:TransportMeansOperatorIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:Party" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseEndorsementText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseEndorsementText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PersonPassportIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="it:TransportMeansOperatorAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>

--- a/xsd/domains/justice.xsd
+++ b/xsd/domains/justice.xsd
@@ -2951,43 +2951,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="DriverLicenseBaseEndorsementType">
-    <xs:annotation>
-      <xs:documentation>A data type for an endorsement on a driver license or driver license permit which authorizes the operation of specified types of vehicles carrying specified loads.</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
-        <xs:sequence>
-          <xs:element ref="j:DriverLicenseEndorsementText" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseEndorsementEndDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseHMEThreatDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseHMEThreatAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseBaseEndorsementAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-  <xs:complexType name="DriverLicenseBaseType">
-    <xs:annotation>
-      <xs:documentation>A data type for an authorization issued to a driver granting driving privileges.</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
-        <xs:sequence>
-          <xs:element ref="j:DriverLicenseCardDesignRevisionDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseIdentification" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseLimitedTermIndicator" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseMedicalCertification" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseExpirationDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseIssueDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicensePerson" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseIssuingCountry" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseREALIDComplianceAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseBaseAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
   <xs:complexType name="DriverLicenseDrivingIncidentAssociationType">
     <xs:annotation>
       <xs:documentation>A data type for an association between a driver license and a driving incident.</xs:documentation>
@@ -3009,87 +2972,11 @@
       <xs:documentation>A data type for an endorsement on a driver license which authorizes the operation of specified types of vehicles carrying specified loads.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="j:DriverLicenseBaseEndorsementType">
+      <xs:extension base="nc:LicenseEndorsementType">
         <xs:sequence>
-          <xs:element ref="j:DriverLicenseEndorsementCode" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="j:DriverLicenseHMEThreatDate" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="j:DriverLicenseHMEThreatAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:DriverLicenseEndorsementAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-  <xs:complexType name="DriverLicenseMedicalCertificationType">
-    <xs:annotation>
-      <xs:documentation>A data type for a medical certification associated with a driver license.</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
-        <xs:sequence>
-          <xs:element ref="j:DriverLicenseMedicalCertificationExpirationDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseMedicalCertificationIssueDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseSkillsPerformanceEvaluationEffectiveDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseSkillsPerformanceEvaluationExpirationDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseWaiverExemptEffectiveDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseWaiverExemptExpirationDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseWaiverExemptExpirationIndefiniteIndicator" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseMedicalCertificationRestrictionAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseMedicalCertificationStatusAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseMedicalSelfCertificationAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseMedicalCertificationAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-  <xs:complexType name="DriverLicensePermitEndorsementType">
-    <xs:annotation>
-      <xs:documentation>A data type for an endorsement on a driver license permit which authorizes the operation of specified types of vehicles carrying specified loads.</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="j:DriverLicenseBaseEndorsementType">
-        <xs:sequence>
-          <xs:element ref="j:DriverLicensePermitEndorsementCode" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicensePermitEndorsementAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-  <xs:complexType name="DriverLicensePermitRestrictionType">
-    <xs:annotation>
-      <xs:documentation>A data type for a restriction applicable to a driver permit.</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="j:DrivingRestrictionType">
-        <xs:sequence>
-          <xs:element ref="j:DriverLicensePermitRestrictionCode" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicensePermitRestrictionAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-  <xs:complexType name="DriverLicensePermitType">
-    <xs:annotation>
-      <xs:documentation>A data type for a driver license permit issued to a driver granting conditional or limited driving privileges.</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="j:DriverLicenseBaseType">
-        <xs:sequence>
-          <xs:element ref="j:DriverLicensePermitClassificationText" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicensePermitStatusAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicensePermitRestriction" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicensePermitEndorsement" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicensePermitAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-  <xs:complexType name="DriverLicenseRestrictionType">
-    <xs:annotation>
-      <xs:documentation>A data type for a restriction applicable to a driver license.</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="j:DrivingRestrictionType">
-        <xs:sequence>
-          <xs:element ref="j:DriverLicenseRestrictionCode" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseRestrictionAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -3099,20 +2986,16 @@
       <xs:documentation>A data type for a license issued to a person granting driving privileges.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="j:DriverLicenseBaseType">
+      <xs:extension base="nc:LicenseType">
         <xs:sequence>
           <xs:element ref="j:DriverLicenseEnhancedIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:DriverLicenseCommercialClassAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:DriverLicenseCommercialStatusAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:DriverLicenseNonCommercialClassText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:DriverLicenseNonCommercialStatusAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicensePermit" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicensePermitQuantity" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:DriverLicenseWithdrawal" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:DriverLicenseWithdrawalPendingIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:DriverLicenseCardIdentification" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseRestriction" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DriverLicenseEndorsement" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:DriverLicenseAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -3172,21 +3055,6 @@
           <xs:element ref="j:DrivingIncidentTrafficDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:DrivingIncidentWeatherDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="j:DrivingIncidentAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-  <xs:complexType name="DrivingRestrictionType">
-    <xs:annotation>
-      <xs:documentation>A data type for a restriction applicable to a driver permit or license.</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
-        <xs:sequence>
-          <xs:element ref="j:DrivingRestrictionAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DrivingRestrictionDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DrivingRestrictionEndDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="j:DrivingRestrictionAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -14440,7 +14308,7 @@
       <xs:documentation>An augmentation point for CrashDriverType.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="CrashDriverAuthorizationRestriction" type="j:DrivingRestrictionType" nillable="true">
+  <xs:element name="CrashDriverAuthorizationRestriction" type="nc:LicenseRestrictionType" nillable="true">
     <xs:annotation>
       <xs:documentation>A restriction on a driver license or driver license permit.</xs:documentation>
     </xs:annotation>
@@ -14495,7 +14363,7 @@
       <xs:documentation>A Type of License assigned by authorizing agent issuing a driver license to the individual.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="CrashDriverLicensePermitStatusCode" type="mmucc:DriverLicensePermitStatusCodeType" substitutionGroup="j:DriverLicensePermitStatusAbstract" nillable="true">
+  <xs:element name="CrashDriverLicensePermitStatusCode" type="mmucc:DriverLicensePermitStatusCodeType" substitutionGroup="nc:LicensePermitStatusAbstract" nillable="true">
     <xs:annotation>
       <xs:documentation>A current status of an individuals driver license at the time of the crash.</xs:documentation>
     </xs:annotation>
@@ -14510,7 +14378,7 @@
       <xs:documentation>A vehicle-related violation, which applies to a driver involved in a crash.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="CrashDrivingRestrictionCode" type="mmucc:DrivingRestrictionCodeType" substitutionGroup="j:DrivingRestrictionAbstract" nillable="true">
+  <xs:element name="CrashDrivingRestrictionCode" type="mmucc:DrivingRestrictionCodeType" substitutionGroup="nc:LicenseRestrictionAbstract" nillable="true">
     <xs:annotation>
       <xs:documentation>A Restriction assigned to an individuals driver license by the license examiner.</xs:documentation>
     </xs:annotation>
@@ -15805,26 +15673,6 @@
       <xs:documentation>An augmentation point for DriverLicenseType.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="DriverLicenseBase" type="j:DriverLicenseBaseType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>An authorization issued to a driver granting driving privileges.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseBaseAugmentationPoint" abstract="true">
-    <xs:annotation>
-      <xs:documentation>An augmentation point for DriverLicenseBaseType.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseBaseEndorsementAugmentationPoint" abstract="true">
-    <xs:annotation>
-      <xs:documentation>An augmentation point for DriverLicenseBaseEndorsementType.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseCardDesignRevisionDate" type="nc:DateType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>An implementation date of the most recent version or modification to the visible design of a jurisdictions driver license or ID card.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
   <xs:element name="DriverLicenseCardIdentification" type="nc:IdentificationType" nillable="true">
     <xs:annotation>
       <xs:documentation>An identification that is affixed to the raw materials (card stock, laminate, etc.) used in producing driver licenses and ID cards. The numbers are issued by the material's manufacturer and provide a unique reference to a card within a jurisdiction.</xs:documentation>
@@ -15875,7 +15723,7 @@
       <xs:documentation>An augmentation point for DriverLicenseDrivingIncidentAssociationType.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="DriverLicenseEndorsement" type="j:DriverLicenseEndorsementType" nillable="true">
+  <xs:element name="DriverLicenseEndorsement" type="j:DriverLicenseEndorsementType" substitutionGroup="nc:LicenseEndorsement" nillable="true">
     <xs:annotation>
       <xs:documentation>An endorsement on a driver license or driver license permit which authorizes the operation of specified types of vehicles carrying specified loads.</xs:documentation>
     </xs:annotation>
@@ -15885,17 +15733,7 @@
       <xs:documentation>An augmentation point for type j:DriverLicenseEndorsementType</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="DriverLicenseEndorsementCode" type="aamva_d20:DrivingEndorsementCodeType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>An endorsement on a driver license or driver license permit which authorizes the operation of specified types of vehicles carrying specified loads.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseEndorsementEndDate" type="nc:DateType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A date on which an endorsement for a driver license ends.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseEndorsementText" type="nc:TextType" nillable="true">
+  <xs:element name="DriverLicenseEndorsementCode" type="aamva_d20:DrivingEndorsementCodeType" substitutionGroup="nc:LicenseEndorsementAbstract" nillable="true">
     <xs:annotation>
       <xs:documentation>An endorsement on a driver license or driver license permit which authorizes the operation of specified types of vehicles carrying specified loads.</xs:documentation>
     </xs:annotation>
@@ -15903,11 +15741,6 @@
   <xs:element name="DriverLicenseEnhancedIndicator" type="niem-xs:boolean" nillable="true">
     <xs:annotation>
       <xs:documentation>True if a driver license is an Enhanced Driver License in accordance with US Department of Homeland Security criteria; false otherwise.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseExpirationDate" type="nc:DateType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A date after which a driver license or driver license permit is no longer valid.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="DriverLicenseHMEThreatAbstract" abstract="true">
@@ -15930,72 +15763,17 @@
       <xs:documentation>A determination if a driver should be issued a HAZMAT Endorsement, as determined by the TSA adjudication process.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="DriverLicenseIdentification" type="nc:IdentificationType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A driver license identification or driver license permit identification, including the number and state.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseIssueDate" type="nc:DateType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A date when a driver license or driver license permit is issued or renewed.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseIssuingCountry" type="nc:CountryType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A country in which an identity document was issued.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseLimitedTermIndicator" type="niem-xs:boolean" nillable="true">
-    <xs:annotation>
-      <xs:documentation>True if a driver license or identification card is classified by DHS regulations as a temporary or limited-term document (i.e. the expiration date of the card is limited to the duration of an aliens legal stay in the U.S.); false otherwise.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseMedicalCertification" type="j:DriverLicenseMedicalCertificationType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A medical certification associated with a driver license.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseMedicalCertificationAugmentationPoint" abstract="true">
-    <xs:annotation>
-      <xs:documentation>An augmentation point for j:DriverLicenseMedicalCertificationType.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseMedicalCertificationExpirationDate" type="nc:DateType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A date on which a medical certificate issued to a commercial driver expires.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseMedicalCertificationIssueDate" type="nc:DateType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A date on which a medical practitioner issued a medical certificate to a commercial driver.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseMedicalCertificationRestrictionAbstract" abstract="true">
-    <xs:annotation>
-      <xs:documentation>A data concept for a restriction imposed on a commercial driver by a medical examiner.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseMedicalCertificationRestrictionCode" type="aamva_d20:DriverLicenseMedicalCertificationRestrictionCodeType" substitutionGroup="j:DriverLicenseMedicalCertificationRestrictionAbstract" nillable="true">
+  <xs:element name="DriverLicenseMedicalCertificationRestrictionCode" type="aamva_d20:DriverLicenseMedicalCertificationRestrictionCodeType" substitutionGroup="nc:LicenseMedicalCertificationRestrictionAbstract" nillable="true">
     <xs:annotation>
       <xs:documentation>A restriction imposed on a commercial driver by a medical examiner.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="DriverLicenseMedicalCertificationStatusAbstract" abstract="true">
-    <xs:annotation>
-      <xs:documentation>A data concept for an indication of the status of a driver's medical certification.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseMedicalCertificationStatusCode" type="aamva_d20:DriverLicenseMedicalCertificationStatusCodeType" substitutionGroup="j:DriverLicenseMedicalCertificationStatusAbstract" nillable="true">
+  <xs:element name="DriverLicenseMedicalCertificationStatusCode" type="aamva_d20:DriverLicenseMedicalCertificationStatusCodeType" substitutionGroup="nc:LicenseMedicalCertificationStatusAbstract" nillable="true">
     <xs:annotation>
       <xs:documentation>An indication of the status of a driver's medical certification.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="DriverLicenseMedicalSelfCertificationAbstract" abstract="true">
-    <xs:annotation>
-      <xs:documentation>A data concept for a driver's self certification of the commercial driver's status regarding 49 CFR 390.3 and the type of driving.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseMedicalSelfCertificationCode" type="aamva_d20:DriverLicenseMedicalSelfCertificationCodeType" substitutionGroup="j:DriverLicenseMedicalSelfCertificationAbstract" nillable="true">
+  <xs:element name="DriverLicenseMedicalSelfCertificationCode" type="aamva_d20:DriverLicenseMedicalSelfCertificationCodeType" substitutionGroup="nc:LicenseMedicalSelfCertificationAbstract" nillable="true">
     <xs:annotation>
       <xs:documentation>A driver's self certification of the commercial driver's status regarding 49 CFR 390.3 and the type of driving.</xs:documentation>
     </xs:annotation>
@@ -16020,124 +15798,39 @@
       <xs:documentation>A current status of an individual's non-commercial privilege (base) type.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="DriverLicensePermit" type="j:DriverLicensePermitType" nillable="true">
+  <xs:element name="DriverLicensePermit" type="nc:LicensePermitType" substitutionGroup="nc:LicensePermit" nillable="true">
     <xs:annotation>
       <xs:documentation>A driver license permit issued to a driver granting conditional or limited driving privileges.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="DriverLicensePermitAugmentationPoint" abstract="true">
-    <xs:annotation>
-      <xs:documentation>An augmentation point for DriverLicensePermitType.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicensePermitClassificationText" type="nc:TextType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A kind of commercial or non-commercial vehicle that a licensed driver has been examined on and approved to operate subject to a permit.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicensePermitEndorsement" type="j:DriverLicensePermitEndorsementType" nillable="true">
+  <xs:element name="DriverLicensePermitEndorsement" type="j:DriverLicenseEndorsementType" substitutionGroup="nc:LicenseEndorsement" nillable="true">
     <xs:annotation>
       <xs:documentation>An endorsement on a driver license which authorizes the operation of specified types of vehicles carrying specified loads.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="DriverLicensePermitEndorsementAugmentationPoint" abstract="true">
-    <xs:annotation>
-      <xs:documentation>An augmentation point for type j:DriverLicensePermitEndorsementType</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicensePermitEndorsementCode" type="aamva_d20:DriverLicensePermitEndorsementCodeType" nillable="true">
+  <xs:element name="DriverLicensePermitEndorsementCode" type="aamva_d20:DriverLicensePermitEndorsementCodeType" substitutionGroup="nc:LicenseEndorsementAbstract" nillable="true">
     <xs:annotation>
       <xs:documentation>An endorsement on a driver license permit which authorizes the operation of specified types of vehicles carrying specified loads.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="DriverLicensePermitQuantity" type="niem-xs:nonNegativeInteger" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A number of driver permits issued on a license.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicensePermitRestriction" type="j:DriverLicensePermitRestrictionType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A restriction on a driver license permit.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicensePermitRestrictionAugmentationPoint" abstract="true">
-    <xs:annotation>
-      <xs:documentation>An augmentation point for type j:DriverLicensePermitRestrictionType</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicensePermitRestrictionCode" type="aamva_d20:DrivingPermitRestrictionCodeType" nillable="true">
+  <xs:element name="DriverLicensePermitRestrictionCode" type="aamva_d20:DrivingPermitRestrictionCodeType" substitutionGroup="nc:LicenseRestrictionAbstract" nillable="true">
     <xs:annotation>
       <xs:documentation>A category of a driving restriction on a permit.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="DriverLicensePermitStatusAbstract" abstract="true">
-    <xs:annotation>
-      <xs:documentation>A data concept for a current status of an individuals driver license permit.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicensePermitStatusCode" type="aamva_d20:DrivingStatusCodeType" substitutionGroup="j:DriverLicensePermitStatusAbstract" nillable="true">
+  <xs:element name="DriverLicensePermitStatusCode" type="aamva_d20:DrivingStatusCodeType" substitutionGroup="nc:LicensePermitStatusAbstract" nillable="true">
     <xs:annotation>
       <xs:documentation>A current status of an individuals driver license permit.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="DriverLicensePermitStatusText" type="nc:TextType" substitutionGroup="j:DriverLicensePermitStatusAbstract" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A current status of an individuals driver license permit.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicensePerson" type="nc:PersonType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A person to which a driver license or driver license permit is assigned.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseREALIDComplianceAbstract" abstract="true">
-    <xs:annotation>
-      <xs:documentation>A data concept for an indication of the degree to which a driver license or ID Card is compliant with the REAL ID A data concept for act.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseREALIDComplianceCode" type="aamva_d20:DriverLicenseREALIDComplianceCodeType" substitutionGroup="j:DriverLicenseREALIDComplianceAbstract" nillable="true">
+  <xs:element name="DriverLicenseREALIDComplianceCode" type="aamva_d20:DriverLicenseREALIDComplianceCodeType" substitutionGroup="nc:IdentificationREALIDComplianceAbstract" nillable="true">
     <xs:annotation>
       <xs:documentation>An indication of the degree to which a driver license or ID Card is compliant with the REAL ID Act.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="DriverLicenseRestriction" type="j:DriverLicenseRestrictionType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A restriction on a driver license.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseRestrictionAugmentationPoint" abstract="true">
-    <xs:annotation>
-      <xs:documentation>An augmentation point for type j:DriverLicenseRestrictionType</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseRestrictionCode" type="aamva_d20:DrivingRestrictionCodeType" nillable="true">
+  <xs:element name="DriverLicenseRestrictionCode" type="aamva_d20:DrivingRestrictionCodeType" substitutionGroup="nc:LicenseRestrictionAbstract" nillable="true">
     <xs:annotation>
       <xs:documentation>A category of a driving restriction on a license.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseSkillsPerformanceEvaluationEffectiveDate" type="nc:DateType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A start date of the most recent variance of a medical certificate, due to a commercial driver's Skills Performance Evaluation.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseSkillsPerformanceEvaluationExpirationDate" type="nc:DateType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>An expiration date of the most recent variance of a medical certificate, due to a commercial driver's Skills Performance Evaluation.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseWaiverExemptEffectiveDate" type="nc:DateType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A start date of the most recent variance of a medical certificate, due to a waiver or exemption.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseWaiverExemptExpirationDate" type="nc:DateType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>An expiration date of the most recent variance of a medical certificate, due to a waiver or exemption.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DriverLicenseWaiverExemptExpirationIndefiniteIndicator" type="niem-xs:boolean" nillable="true">
-    <xs:annotation>
-      <xs:documentation>True if the expiration date of the most recent variance of a medical certificate is indefinite; false otherwise.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="DriverLicenseWithdrawal" type="j:DriverLicenseWithdrawalType" nillable="true">
@@ -16435,34 +16128,9 @@
       <xs:documentation>A driving offense designation as specified by the AAMVA Code Dictionary (ACD).</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="DrivingRestriction" type="j:DrivingRestrictionType" nillable="true">
+  <xs:element name="DrivingRestriction" type="nc:LicenseRestrictionType" nillable="true">
     <xs:annotation>
       <xs:documentation>A restriction applicable to a driver permit or license.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DrivingRestrictionAbstract" abstract="true">
-    <xs:annotation>
-      <xs:documentation>A data concept for a driving restriction.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DrivingRestrictionAugmentationPoint" abstract="true">
-    <xs:annotation>
-      <xs:documentation>An augmentation point for DrivingRestrictionType.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DrivingRestrictionDescriptionText" type="nc:TextType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A description of the nature of a restriction</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DrivingRestrictionEndDate" type="nc:DateType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A date on which a special restriction ends.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="DrivingRestrictionText" type="nc:TextType" substitutionGroup="j:DrivingRestrictionAbstract" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A category of a driving restriction.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="DrugAugmentation" type="j:DrugAugmentationType" substitutionGroup="nc:DrugAugmentationPoint" nillable="true">

--- a/xsd/domains/maritime.xsd
+++ b/xsd/domains/maritime.xsd
@@ -1250,35 +1250,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="MerchantMarinerDocumentType">
-    <xs:annotation>
-      <xs:documentation>A data type for a Merchant Mariner Document (MMD).</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
-        <xs:sequence>
-          <xs:element ref="m:MerchantMarinerDocumentIdentification" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="m:MerchantMarinerDocumentIssueDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="m:MerchantMarinerDocumentIssuerLocation" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="m:MerchantMarinerDocumentIssuingOrganization" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="m:MerchantMarinerDocumentRatingAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="m:PersonAddress" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonBirthDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonCitizenshipCountry" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonEyeColorAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonHairColorAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonHeightDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonHeightMeasure" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonName" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonSexAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonSSNIdentification" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonWeightDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonWeightMeasure" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="m:MerchantMarinerDocumentAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
   <xs:complexType name="NextPortOfCallListType">
     <xs:annotation>
       <xs:documentation>A data type for a list of ports that will be visited subsequently.</xs:documentation>
@@ -1461,35 +1432,6 @@
         <xs:sequence>
           <xs:element ref="m:PreviousForeignPortOfCall" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="m:PreviousForeignPortOfCallListAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-  <xs:complexType name="SeamanLicenseType">
-    <xs:annotation>
-      <xs:documentation>A data type for an able-bodied seaman license.</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="structures:ObjectType">
-        <xs:sequence>
-          <xs:element ref="m:PersonAddress" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonBirthDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonCitizenshipCountry" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonEyeColorAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonHairColorAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonHeightDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonHeightMeasure" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonName" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonSexAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonSSNIdentification" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonWeightDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonWeightMeasure" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="m:SeamanLicenseIdentification" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="m:SeamanLicenseIssueDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="m:SeamanLicenseIssuerLocation" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="m:SeamanLicenseIssuingOrganization" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="m:SeamanLicenseRatingAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="m:SeamanLicenseAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -2264,44 +2206,9 @@
       <xs:documentation>A location identified by a United Nations Location Code, also known as a UN/LOCODE (United Nations Code for Trade and Transport Locations).</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="MerchantMarinerDocument" type="m:MerchantMarinerDocumentType" nillable="true">
+  <xs:element name="MerchantMarinerDocument" type="nc:LicenseType" nillable="true">
     <xs:annotation>
       <xs:documentation>A Merchant Mariner Document (MMD) issued to a merchant mariner.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="MerchantMarinerDocumentAugmentationPoint" abstract="true">
-    <xs:annotation>
-      <xs:documentation>An augmentation point for MerchantMarinerDocumentType.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="MerchantMarinerDocumentIdentification" type="nc:IdentificationType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>An identification of a merchant mariner document.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="MerchantMarinerDocumentIssueDate" type="nc:DateType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A date a merchant mariner document was issued.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="MerchantMarinerDocumentIssuerLocation" type="nc:LocationType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A location of the issuer of a merchant mariner document.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="MerchantMarinerDocumentIssuingOrganization" type="nc:OrganizationType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>An issuer of a merchant mariner document.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="MerchantMarinerDocumentRatingAbstract" abstract="true">
-    <xs:annotation>
-      <xs:documentation>A data concept for a rating on a merchant mariner document which authorizes the performance of certain shipboard duties or actions.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="MerchantMarinerDocumentRatingText" type="nc:TextType" substitutionGroup="m:MerchantMarinerDocumentRatingAbstract" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A rating on a merchant mariner document which authorizes the performance of certain shipboard duties or actions.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="NextPortOfCall" type="m:PortVisitType" nillable="true">
@@ -2372,11 +2279,6 @@
   <xs:element name="NonCrewNationalityQuantity" type="niem-xs:nonNegativeInteger" nillable="true">
     <xs:annotation>
       <xs:documentation>A count of passengers of a particular nationality</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="PersonAddress" type="nc:AddressType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>An address for a person.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="PersonAugmentation" type="m:PersonAugmentationType" substitutionGroup="nc:PersonAugmentationPoint" nillable="true">
@@ -2659,44 +2561,14 @@
       <xs:documentation>An identification of a passenger name record (PNR).</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="SeamanLicense" type="m:SeamanLicenseType" nillable="true">
+  <xs:element name="SeamanLicense" type="nc:LicenseType" nillable="true">
     <xs:annotation>
       <xs:documentation>An able-bodied seaman license issued to a person.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="SeamanLicenseAugmentationPoint" abstract="true">
-    <xs:annotation>
-      <xs:documentation>An augmentation point for SeamanLicenseType.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="SeamanLicenseIdentification" type="nc:IdentificationType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>An identification of a seaman license.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="SeamanLicenseIssueDate" type="nc:DateType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A date a seaman license was issued.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="SeamanLicenseIssuerLocation" type="nc:LocationType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A location of an issuer of a seaman license.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="SeamanLicenseIssuingOrganization" type="nc:OrganizationType" nillable="true">
     <xs:annotation>
       <xs:documentation>An issuer of a seaman license.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="SeamanLicenseRatingAbstract" abstract="true">
-    <xs:annotation>
-      <xs:documentation>A data concept for a rating on a seaman license which authorizes the performance of certain shipboard duties or actions.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="SeamanLicenseRatingText" type="nc:TextType" substitutionGroup="m:SeamanLicenseRatingAbstract" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A rating on a seaman license which authorizes the performance of certain shipboard duties or actions.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Shipment" type="m:ShipmentType" nillable="true">

--- a/xsd/domains/screening.xsd
+++ b/xsd/domains/screening.xsd
@@ -17992,18 +17992,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="IdentificationAugmentationType">
-    <xs:annotation>
-      <xs:documentation>A data type for additional information about an identification.</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="structures:AugmentationType">
-        <xs:sequence>
-          <xs:element ref="scr:IdentificationStatusAdvisoryText" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
   <xs:complexType name="ImageFeatureExtractionType">
     <xs:annotation>
       <xs:documentation>A data type that specifies details of the image extraction</xs:documentation>
@@ -20629,6 +20617,8 @@
         <xs:sequence>
           <xs:element ref="scr:SoundexIndexValueText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:PersonNameOriginText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="scr:PersonPrimaryName" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="scr:PersonSecondaryName" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:DesignationCategoryAbstract" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
         <xs:attribute ref="scr:nameTranslationCategoryCode" use="optional"/>
@@ -20766,7 +20756,7 @@
           <xs:element ref="im:SEVISID" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:PhotoRequestIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:AdmittedDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="scr:IdentificationStatusAdvisoryText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationStatusAdvisoryText" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="scr:PersonSearchResultAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -20916,6 +20906,38 @@
       </xs:enumeration>
     </xs:restriction>
   </xs:simpleType>
+  <xs:simpleType name="PilotLicenseMedicalAssessmentCategoryCodeSimpleType">
+    <xs:annotation>
+      <xs:documentation>A data type for a kind of medical assessment for a pilot license.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>A 1st Class medical is required when flight operations require an Air Transport Pilot (ATP) certificate.  An ATP is required to act as the Pilot in Command (PIC) or Captain of a scheduled airliner.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>A 2nd Class medical is required when flight operations require a Commercial Pilot certificate.  A Commercial certificate is required essentially to get paid to be a pilot.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>A 3rd Class medical is required for all other flight operations that require an FAA Medical Certificate.  This includes Student Pilots pursuing a Recreational or Private certificate, Recreational and Private pilots, and most Flight Instructors.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="PilotLicenseMedicalAssessmentCategoryCodeType">
+    <xs:annotation>
+      <xs:documentation>A data type for a kind of medical assessment for a pilot license.</xs:documentation>
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="scr:PilotLicenseMedicalAssessmentCategoryCodeSimpleType">
+        <xs:attributeGroup ref="structures:SimpleObjectAttributeGroup"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
   <xs:simpleType name="RiskCategoryCodeSimpleType">
     <xs:annotation>
       <xs:documentation>A data type describing the kinds of risk categories for screening purposes</xs:documentation>
@@ -23008,16 +23030,6 @@
       <xs:documentation>True if the person arrested has requested a court hearing; false otherwise.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="IdentificationAugmentation" type="scr:IdentificationAugmentationType" substitutionGroup="nc:IdentificationAugmentationPoint" nillable="true">
-    <xs:annotation>
-      <xs:documentation>Additional information about an identification.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="IdentificationStatusAdvisoryText" type="nc:TextType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>A text that describes special or advisory information about a particular Identification ID</xs:documentation>
-    </xs:annotation>
-  </xs:element>
   <xs:element name="IdentityStatusAbstract" abstract="true">
     <xs:annotation>
       <xs:documentation>A data concept for an aggregated status of biometrically linked encounters for an identified individual.</xs:documentation>
@@ -23808,6 +23820,11 @@
       <xs:documentation>An augmentation point for PersonPhoneAssociationType.</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="PersonPrimaryName" type="nc:PersonNameTextType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A primary name of a person, which may be the family name, the maiden name, the surname, or the entire name in cases where the name cannot be divided into two parts.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="PersonRole" type="scr:PersonRoleType" nillable="true">
     <xs:annotation>
       <xs:documentation>A part played by a Person in an Encounter.</xs:documentation>
@@ -23868,6 +23885,11 @@
       <xs:documentation>An augmentation point for PersonSearchResultType.</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="PersonSecondaryName" type="nc:PersonNameTextType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A secondary name of a person, which may include given names, middle names, forenames, familiar names, initials, or any other secondary names.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="PersonStatusSummary" type="scr:PersonStatusSummaryType" nillable="true">
     <xs:annotation>
       <xs:documentation>A status of Person involved in a Screening Encounter.</xs:documentation>
@@ -23901,6 +23923,11 @@
   <xs:element name="PhysicalEncounterAgentAssociationAugmentationPoint" abstract="true">
     <xs:annotation>
       <xs:documentation>An augmentation point for PhysicalEncounterAgentAssociationType.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="PilotLicenseMedicalAssessmentCategoryCode" type="scr:PilotLicenseMedicalAssessmentCategoryCodeType" substitutionGroup="nc:LicenseMedicalAssessmentCategoryAbstract" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A kind of medical assessment for a pilot license.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="PrimaryDispositionText" type="nc:TextType" nillable="true">

--- a/xsd/niem-core.xsd
+++ b/xsd/niem-core.xsd
@@ -2112,13 +2112,33 @@
       <xs:extension base="structures:ObjectType">
         <xs:sequence>
           <xs:element ref="nc:IdentificationID" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationPerson" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:IdentificationJurisdiction" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationCardDesignRevisionDate" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:IdentificationCategoryAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:IdentificationCategoryDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationElectronicIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:IdentificationEffectiveDate" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:IdentificationExpirationDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:IdentificationSourceText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationIssueDate" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationIssuerAdministrativeID" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationIssuerComment" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationIssuerCountry" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationIssuerLocalityText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationIssuerLocation" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationIssuerOrganization" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationIssuerState" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationIssuerSymbolImage" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationIssuerText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationLimitedTermIndicator" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationREALIDComplianceAbstract" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationSealImage" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationSignatureAuthorityName" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:IdentificationStatus" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationStatusAdvisoryText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationStolenLostIndicator" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationTitleText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:IdentificationUNDistinguishingSignID" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:IdentificationAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
@@ -2585,6 +2605,96 @@
         <xs:sequence>
           <xs:element ref="nc:LengthUnitAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:LengthMeasureAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="LicenseEndorsementType">
+    <xs:annotation>
+      <xs:documentation>A data type for an endorsement on a license or license permit which authorizes specific privileges.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="structures:ObjectType">
+        <xs:sequence>
+          <xs:element ref="nc:LicenseEndorsementEndDate" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseEndorsementAbstract" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseEndorsementAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="LicenseMedicalCertificationType">
+    <xs:annotation>
+      <xs:documentation>A data type for a medical certification associated with a license.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="structures:ObjectType">
+        <xs:sequence>
+          <xs:element ref="nc:LicenseMedicalAssessmentCategoryAbstract" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseMedicalAssessmentDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseMedicalCertificationExpirationDate" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseMedicalCertificationIssueDate" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseSkillsPerformanceEvaluationEffectiveDate" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseSkillsPerformanceEvaluationExpirationDate" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseWaiverExemptEffectiveDate" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseWaiverExemptExpirationDate" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseWaiverExemptExpirationIndefiniteIndicator" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseMedicalCertificationRestrictionAbstract" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseMedicalCertificationStatusAbstract" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseMedicalSelfCertificationAbstract" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseMedicalLimitationText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseMedicalCertificationAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="LicensePermitType">
+    <xs:annotation>
+      <xs:documentation>A data type for a license permit issued to a person granting conditional or limited privileges.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="nc:LicenseType">
+        <xs:sequence>
+          <xs:element ref="nc:LicensePermitClassificationText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicensePermitStatusAbstract" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicensePermitRestriction" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicensePermitEndorsement" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicensePermitAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="LicenseRestrictionType">
+    <xs:annotation>
+      <xs:documentation>A data type for a restriction applicable to a permit or license.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="structures:ObjectType">
+        <xs:sequence>
+          <xs:element ref="nc:LicenseRestrictionAbstract" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseRestrictionDescriptionText" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseRestrictionEndDate" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseRestrictionAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="LicenseType">
+    <xs:annotation>
+      <xs:documentation>A data type for an authorization issued to a person granting certain privileges.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="nc:IdentificationType">
+        <xs:sequence>
+          <xs:element ref="nc:LicenseMedicalCertification" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseRatingAbstract" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseRatingEffectiveDate" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseRatingExpirationDate" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicensePermit" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicensePermitQuantity" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseRestriction" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseEndorsement" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:LicenseAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -3317,20 +3427,11 @@
       <xs:documentation>A data type for a government-issued document that authenticates the identity and citizenship of a person.</xs:documentation>
     </xs:annotation>
     <xs:complexContent>
-      <xs:extension base="nc:DocumentType">
+      <xs:extension base="nc:IdentificationType">
         <xs:sequence>
           <xs:element ref="nc:PassportNumberIdentification" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonName" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonBirthDate" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonBirthLocation" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PassportBookIdentification" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PassportCategoryAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonDigitalImage" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonCitizenshipCountry" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PassportElectronicIndicator" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PassportIssuingOrganization" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PersonSexAbstract" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element ref="nc:PassportStolenLostIndicator" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PassportTransmissionTrackingID" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PassportAugmentationPoint" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
@@ -3793,6 +3894,7 @@
           <xs:element ref="nc:PersonPronounsAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PersonRaceAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PersonReligionAbstract" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="nc:PersonResidenceAddress" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PersonResidentAbstract" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PersonSecondaryLanguage" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element ref="nc:PersonSecurityClearanceAbstract" minOccurs="0" maxOccurs="unbounded"/>
@@ -8503,6 +8605,11 @@
       <xs:documentation>An augmentation point for IdentificationType.</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="IdentificationCardDesignRevisionDate" type="nc:DateType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>An implementation date of the most recent version or modification to the visible design of a license or ID card.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="IdentificationCategoryAbstract" abstract="true">
     <xs:annotation>
       <xs:documentation>A data concept for a kind of identification.</xs:documentation>
@@ -8523,6 +8630,11 @@
       <xs:documentation>A date an identification takes effect.</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="IdentificationElectronicIndicator" type="niem-xs:boolean" nillable="true">
+    <xs:annotation>
+      <xs:documentation>True if an identification document is RFID enabled; false otherwise.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="IdentificationExpirationDate" type="nc:DateType" nillable="true">
     <xs:annotation>
       <xs:documentation>A date after which an identification is no longer valid.</xs:documentation>
@@ -8533,19 +8645,109 @@
       <xs:documentation>An identifier.</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:element name="IdentificationIssueDate" type="nc:DateType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A date when an identification is issued or renewed.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="IdentificationIssuerAdministrativeID" type="niem-xs:string" nillable="true">
+    <xs:annotation>
+      <xs:documentation>An identifier, such as an audit control number, assigned by the issuing authority of the identification.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="IdentificationIssuerComment" type="nc:CommentType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A comment or remark made about an identification by the issuing authority.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="IdentificationIssuerCountry" type="nc:CountryType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A country which issued an identification.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="IdentificationIssuerLocalityText" type="nc:TextType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A locality or other subdivision of a state which issued an identification.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="IdentificationIssuerLocation" type="nc:LocationType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A location of an issuer of an identification.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="IdentificationIssuerOrganization" type="nc:OrganizationType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>An organization that issued an identification.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="IdentificationIssuerState" type="nc:StateType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A state which issued an identification.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="IdentificationIssuerSymbolImage" type="nc:ImageType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A binary image of the symbol or logo of the organization that issued the identification.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="IdentificationIssuerText" type="nc:TextType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A person, organization, or locale which issues an identification.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
   <xs:element name="IdentificationJurisdiction" type="nc:JurisdictionType" nillable="true">
     <xs:annotation>
       <xs:documentation>An area, region, or unit where a unique identification is issued.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="IdentificationSourceText" type="nc:TextType" nillable="true">
+  <xs:element name="IdentificationLimitedTermIndicator" type="niem-xs:boolean" nillable="true">
     <xs:annotation>
-      <xs:documentation>A person, organization, or locale which issues an identification.</xs:documentation>
+      <xs:documentation>True if a license or identification card is classified by DHS or other agency regulations as a temporary or limited-term document (e.g., the expiration date of the card is limited to the duration of an aliens legal stay in the U.S.); false otherwise.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="IdentificationPerson" type="nc:PersonType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A set of characteristics captured about a person for an identification.  These characteristics may be accurate, out of date, verified, or self-asserted.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="IdentificationREALIDComplianceAbstract" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A data concept for an indication of the degree to which a driver license or ID Card is compliant with the REAL ID A data concept for act.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="IdentificationSealImage" type="nc:ImageType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>An image of a seal or stamp of the identification issuer.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="IdentificationSignatureAuthorityName" type="nc:TextType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A name of the signature authority on an identification document.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="IdentificationStatus" type="nc:StatusType" nillable="true">
     <xs:annotation>
       <xs:documentation>A status of an identification.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="IdentificationStatusAdvisoryText" type="nc:TextType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>An advisory or special information about the status of an identification.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="IdentificationStolenLostIndicator" type="niem-xs:boolean" nillable="true">
+    <xs:annotation>
+      <xs:documentation>True if an identification is stolen or lost; false otherwise.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="IdentificationTitleText" type="nc:TextType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A title of an identification.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="IdentificationUNDistinguishingSignID" type="niem-xs:string" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A distinguishing sign identifier of the country which issued an identification, according to ISO/IEC 18013-1:2018, Annex F.  If not applicable, the value may be left blank or may use an internationally-recognized identifier..</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Identity" type="nc:IdentityType" nillable="true">
@@ -9441,6 +9643,206 @@
   <xs:element name="LengthUnitAbstract" abstract="true">
     <xs:annotation>
       <xs:documentation>A data concept for a unit of measure for length.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for LicenseType.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseEndorsement" type="nc:LicenseEndorsementType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>An endorsement on a license which authorizes additional privileges.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseEndorsementAbstract" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A data concept for an endorsement on a license or license permit which authorizes specific privileges.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseEndorsementAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for LicenseEndorsementType.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseEndorsementEndDate" type="nc:DateType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A date on which an endorsement for a license ends.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseEndorsementText" type="nc:TextType" substitutionGroup="nc:LicenseEndorsementAbstract" nillable="true">
+    <xs:annotation>
+      <xs:documentation>An endorsement on a license or license permit which authorizes specific privileges.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseMedicalAssessmentCategoryAbstract" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A data concept for a kind of medical assessment for a license holder.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseMedicalAssessmentCategoryText" type="nc:TextType" substitutionGroup="nc:LicenseMedicalAssessmentCategoryAbstract" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A kind of medical assessment for a license holder.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseMedicalAssessmentDescriptionText" type="nc:TextType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A description of a medical assessment as determined by a medical authority for a license certification.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseMedicalCertification" type="nc:LicenseMedicalCertificationType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A medical certification associated with a license.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseMedicalCertificationAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for LicenseMedicalCertificationType.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseMedicalCertificationExpirationDate" type="nc:DateType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A date on which a medical certificate issued to a license holder expires.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseMedicalCertificationIssueDate" type="nc:DateType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A date on which a medical practitioner issued a medical certificate to a license holder.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseMedicalCertificationRestrictionAbstract" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A data concept for a restriction imposed on a license holder by a medical examiner.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseMedicalCertificationStatusAbstract" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A data concept for an indication of the status of a license holder's medical certification.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseMedicalLimitationText" type="nc:TextType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A medical limitation on a license holder.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseMedicalSelfCertificationAbstract" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A data concept for a license holder's self certification of the license holder's status.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicensePermit" type="nc:LicensePermitType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A permit issued to a person granting conditional or limited privileges.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicensePermitAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for LicensePermitType.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicensePermitClassificationText" type="nc:TextType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A kind of privilege a person has been examined on and approved for subject to a permit.  For a driver license, this would be a kind of commercial or non-commercial vehicle that a licensed driver is approved to operate.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicensePermitEndorsement" type="nc:LicenseEndorsementType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>An endorsement on a license permit which authorizes additional privileges.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicensePermitQuantity" type="niem-xs:nonNegativeInteger" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A number of permits issued on a license.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicensePermitRestriction" type="nc:LicenseRestrictionType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A restriction on a license permit.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicensePermitStatusAbstract" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A data concept for a current status of an individual's license permit.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicensePermitStatusText" type="nc:TextType" substitutionGroup="nc:LicensePermitStatusAbstract" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A current status of an individual's license permit.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseRatingAbstract" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A data concept for rating on a license which authorizes the performance of certain duties or actions.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseRatingEffectiveDate" type="nc:DateType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A date a license rating becomes effective.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseRatingExpirationDate" type="nc:DateType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A date a license rating is no longer valid.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseRatingText" type="nc:TextType" substitutionGroup="nc:LicenseRatingAbstract" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A rating on a license which authorizes the performance of certain duties or actions.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseRestriction" type="nc:LicenseRestrictionType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A restriction on a license.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseRestrictionAbstract" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A data concept about a restriction on a license.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseRestrictionAugmentationPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An augmentation point for LicenseRestrictionType.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseRestrictionDescriptionText" type="nc:TextType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A description of the nature of a restriction on a license.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseRestrictionEndDate" type="nc:DateType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A date on which a special restriction on a license ends.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseRestrictionText" type="nc:TextType" substitutionGroup="nc:LicenseRestrictionAbstract" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A restriction on a license.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseSkillsPerformanceEvaluationEffectiveDate" type="nc:DateType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A start date of the most recent variance of a medical certificate, due to a license holder's Skills Performance Evaluation.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseSkillsPerformanceEvaluationExpirationDate" type="nc:DateType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>An expiration date of the most recent variance of a medical certificate, due to a license holder's Skills Performance Evaluation.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseWaiverExemptEffectiveDate" type="nc:DateType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>A start date of the most recent variance of a medical certificate, due to a waiver or exemption.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseWaiverExemptExpirationDate" type="nc:DateType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>An expiration date of the most recent variance of a medical certificate, due to a waiver or exemption.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LicenseWaiverExemptExpirationIndefiniteIndicator" type="niem-xs:boolean" nillable="true">
+    <xs:annotation>
+      <xs:documentation>True if the expiration date of the most recent variance of a medical certificate is indefinite; false otherwise.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="Locale" type="nc:LocaleType" nillable="true">
@@ -10908,24 +11310,9 @@
       <xs:documentation>A kind of passport.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="PassportElectronicIndicator" type="niem-xs:boolean" nillable="true">
-    <xs:annotation>
-      <xs:documentation>True if the passport document is RFID enabled; false otherwise.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="PassportIssuingOrganization" type="nc:OrganizationType" nillable="true">
-    <xs:annotation>
-      <xs:documentation>An organization that issued a passport.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
   <xs:element name="PassportNumberIdentification" type="nc:IdentificationType" nillable="true">
     <xs:annotation>
       <xs:documentation>An identification of a passport.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-  <xs:element name="PassportStolenLostIndicator" type="niem-xs:boolean" nillable="true">
-    <xs:annotation>
-      <xs:documentation>True if a passport is stolen or lost; false otherwise.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="PassportTransmissionTrackingID" type="niem-xs:string" nillable="true">
@@ -11786,6 +12173,11 @@
   <xs:element name="PersonReligionText" type="nc:TextType" substitutionGroup="nc:PersonReligionAbstract" nillable="true">
     <xs:annotation>
       <xs:documentation>A religion to which a person subscribes or believes; a categorization of spiritual beliefs.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="PersonResidenceAddress" type="nc:AddressType" nillable="true">
+    <xs:annotation>
+      <xs:documentation>An address where a person lives.</xs:documentation>
     </xs:annotation>
   </xs:element>
   <xs:element name="PersonResidenceAssociation" type="nc:PersonResidenceAssociationType" nillable="true">


### PR DESCRIPTION
### Add support for new digital identification and license requirements (#37)

The Department of Homeland Security (DHS) is working to establish digital identity standards. This will help the 50 states harmonize their digital identity attributes such as driver licenses, FAA licenses such as pilot licenses, TSA inner system to system communications for validation of identity documentation, coast guard marine licenses, DoT related Truck licenses and more.

The Emergency Management domain has worked with several states and the FAA to harmonize an initial set of requirements.  Existing identification- and license-related components in NIEM have been reviewed and refactored as needed to support the new requirements.

Key changes include:

- `nc:IdentificationType`
  - Added new properties
  - Added refactored properties from domain augmentations

- `nc:LicenseType`

  - Added as a new type to support other kinds of licenses.
  - Extends `nc:IdentificationType`
  - Added new properties
  - Added refactored properties from `j:DriverLicenseBaseType`

- `j:DriverLicenseType` and related types

  - Updated to extend the new `nc:LicenseType`
  - Refactored the more generic properties to `nc:LicenseType` and related types
  - Added "driver license, DL" keywords to former driver license-specific properties to support the ability for users to find these properties under new, more generic names

- `nc:PassportType`

  - Updated to extend `nc:IdentificationType`
  - Removed individual person-specific properties like `nc:PersonName` and `nc:PersonBirthDate` in favor of the new `nc:IdentificationPerson` property which supports the use of any property from `nc:PersonType` or an augmentation of it

- `em:PersonIDCardType`

  - Refactored and moved some properties to `nc:IdentificationType`
  - Converted to an augmentation of `nc:IdentificationType`

- `m:SeamanLicenseType`

  - Refactored and moved some ratings properties to the new `nc:LicenseType`
  - Removed this type because its contents can now be represented by the new `nc:LicenseType`
  - Changed property `m:SeamanLicense` to type `nc:LicenseType`

- `m:MerchantMarinerDocumentType`

  - Removed this type because its contents can now be represented by the new `nc:LicenseType`
  - Changed property `m:MerchantMarinerDocument` to type `nc:LicenseType`
